### PR TITLE
Allow use of environment variables as an alternative to database credentials in application.properties

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/DataSourceConfig.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/DataSourceConfig.kt
@@ -1,0 +1,39 @@
+package be.osoc.team1.backend
+
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.Properties
+import javax.sql.DataSource
+
+@Configuration
+class DataSourceConfig {
+    private lateinit var applicationProperties: Properties
+
+    /**
+     * A helper function that gets the value of the environment variable [name]. When the environment variable is not
+     * set it will get the property [propertyName] from the application.properties file. The application.properties file
+     * is lazily loaded and reused for subsequent requests.
+     */
+    private fun getProperty(name: String, propertyName: String): String {
+        var value = System.getenv(name)
+        if (value == null) {
+            if (!this::applicationProperties.isInitialized) {
+                applicationProperties = Properties()
+                applicationProperties.load(javaClass.classLoader.getResourceAsStream("application.properties"))
+            }
+            value = applicationProperties.getProperty(propertyName)
+        }
+        return value
+    }
+
+    @Bean
+    fun getDataSource(): DataSource {
+        val dataSourceBuilder = DataSourceBuilder.create()
+        dataSourceBuilder.driverClassName("org.postgresql.Driver")
+        dataSourceBuilder.url(getProperty("OSOC_DB_URL", "spring.datasource.url"))
+        dataSourceBuilder.username(getProperty("OSOC_DB_USERNAME", "spring.datasource.username"))
+        dataSourceBuilder.password(getProperty("OSOC_DB_PASSWORD", "spring.datasource.password"))
+        return dataSourceBuilder.build()
+    }
+}


### PR DESCRIPTION
This allows getting the password, username and/or url for the database from the respective `OSOC_DB_PASSWORD`, `OSOC_DB_USERNAME` and `OSOC_DB_URL` env variables if they are set. In the case that they are not set default values from the `application.properties` file will be used just like before this merge request.