### PR TITLE
chore: remove ktlint from pom.xml

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -84,7 +84,7 @@
 					</dependency>
 				</dependencies>
 			</plugin>
-			<plugin>
+<!-- 			<plugin>
 				<groupId>com.github.gantsign.maven</groupId>
 				<artifactId>ktlint-maven-plugin</artifactId>
 				<version>1.11.2</version>
@@ -97,7 +97,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 		</plugins>
 	</build>
 


### PR DESCRIPTION
gantsign ktlint formatting does not work with current maven / java version