### PR TITLE
Add dokka maven plugin

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -152,15 +152,6 @@
 						</goals>
 					</execution>
 				</executions>
-				<configuration>
-					<dokkaPlugins>
-						<plugin>
-							<groupId>org.jetbrains.dokka</groupId>
-							<artifactId>kotlin-as-java-plugin</artifactId>
-							<version>${dokka.version}</version>
-						</plugin>
-					</dokkaPlugins>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This pull request adds the dokka maven plugin allowing you to generate documentation with `./mvnw dokka:dokka`. The docs will end up in `target/dokka`.
