### PR TITLE
Fix for Jacoco ignoring StudentServiceTests

### DIFF
--- a/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentServiceTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentServiceTests.kt
@@ -12,9 +12,9 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull


### PR DESCRIPTION
This should fix and close #74 
~~Please don't review this request until codecov report is published and shows StudentService code as covered by tests.~~
Confirmed fixed by changing import for ```@Test``` to ```import org.junit.jupiter.api.Test```