### PR TITLE
Increase token valid time

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/security/AuthenticationFilter.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/security/AuthenticationFilter.kt
@@ -58,7 +58,7 @@ class AuthenticationFilter(authenticationManager: AuthenticationManager?) :
         authentication: Authentication
     ) {
         val authenticatedUser: User = authentication.principal as User
-        val accessToken: String = createToken(authenticatedUser, 5)
+        val accessToken: String = createToken(authenticatedUser, 30)
 
         val tokens: MutableMap<String, String> = HashMap()
         tokens["accessToken"] = accessToken


### PR DESCRIPTION
Increases the token valid time from 5 to 30 minutes, this to be less annoying during the demo.