### PR TITLE
Login endpoint documentation

### DIFF
--- a/docs/osoc.yaml
+++ b/docs/osoc.yaml
@@ -760,6 +760,11 @@ paths:
                                 properties:
                                     accessToken:
                                         type: string
+                                    refreshToken:
+                                        type: string
+                                    refreshTokenTTL:
+                                        type: integer
+                                        format: date
                                     user:
                                         $ref: '#/components/schemas/User'
                 '401':


### PR DESCRIPTION
Closes #124

There is only 1 new endpoint and that is /login to get the accessToken. /logout is currently not doing anything and isn't working. We will be looking into that.

### Checklist

**New feature checklist**:
- [x] I've updated the `osoc.yaml` file
