### PR TITLE
Reduce code duplication in list serializers

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/ListSerializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/ListSerializer.kt
@@ -1,0 +1,31 @@
+package be.osoc.team1.backend.util
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
+/**
+ * This class is used to serialize a list of [T] objects when it is used as a reference.
+ * This makes sure it gets turned into a list containing their corresponding rest API urls.
+ */
+open class ListSerializer<T>(private val genFunc: (T) -> String, t: Class<List<T>>?) : StdSerializer<List<T>>(t) {
+    constructor(func: (T) -> String) : this(func, null) {}
+
+    override fun serialize(items: List<T>?, gen: JsonGenerator?, provider: SerializerProvider?) {
+        val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+        if (gen != null) {
+            gen.writeStartArray()
+            if (items != null) {
+                for (s in items) {
+                    gen.writeObject(baseUrl + genFunc(s))
+                }
+            }
+            gen.writeEndArray()
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/StudentListSerializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/StudentListSerializer.kt
@@ -1,32 +1,9 @@
 package be.osoc.team1.backend.util
 
 import be.osoc.team1.backend.entities.Student
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 /**
  * This class is used to serialize a list of [Student] objects when it is used as a reference.
  * This makes sure it gets turned into a list containing their corresponding rest API urls.
  */
-class StudentListSerializer protected constructor(t: Class<List<Student>>?) : StdSerializer<List<Student>>(t) {
-    constructor() : this(null) {}
-
-    override fun serialize(students: List<Student>?, gen: JsonGenerator?, provider: SerializerProvider?) {
-        val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
-        if (gen != null) {
-            gen.writeStartArray()
-            if (students != null) {
-                for (s in students) {
-                    gen.writeObject(baseUrl + "/students/" + s.id.toString())
-                }
-            }
-            gen.writeEndArray()
-        }
-    }
-
-    companion object {
-        private const val serialVersionUID = 1L
-    }
-}
+class StudentListSerializer : ListSerializer<Student>({ "/students/" + it.id.toString() })

--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/UserListSerializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/UserListSerializer.kt
@@ -1,32 +1,9 @@
 package be.osoc.team1.backend.util
 
 import be.osoc.team1.backend.entities.User
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 /**
  * This class is used to serialize a list of [User] objects when it is used as a reference.
  * This makes sure it gets turned into a list containing their corresponding rest API urls.
  */
-class UserListSerializer protected constructor(t: Class<List<User>>?) : StdSerializer<List<User>>(t) {
-    constructor() : this(null) {}
-
-    override fun serialize(users: List<User>?, gen: JsonGenerator?, provider: SerializerProvider?) {
-        val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
-        if (gen != null) {
-            gen.writeStartArray()
-            if (users != null) {
-                for (u in users) {
-                    gen.writeObject(baseUrl + "/users/" + u.id.toString())
-                }
-            }
-            gen.writeEndArray()
-        }
-    }
-
-    companion object {
-        private const val serialVersionUID = 1L
-    }
-}
+class UserListSerializer : ListSerializer<User>({ "/users/" + it.id.toString() })


### PR DESCRIPTION
Closes #207.

This pr reduces code duplication in list serializers found in #193.

This allows the User and Student List serializers to be written in just a few lines of code:
```kotlin
class StudentListSerializer : ListSerializer<Student>({ "/students/" + it.id.toString() })
class UserListSerializer : ListSerializer<User>({ "/users/" + it.id.toString() })
```