### PR TITLE
Add baseclass with shared code between Serializer and ListSerializer

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/BaseSerializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/BaseSerializer.kt
@@ -1,0 +1,18 @@
+package be.osoc.team1.backend.util
+
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
+/**
+ * This is an abstract class containing shared code between our serializers. This allows us to work with a much
+ * simpler constructor for all other serializers and makes it so that the [baseUrl] code is only in one place.
+ */
+abstract class BaseSerializer<T>(t: Class<T>?) : StdSerializer<T>(t) {
+    constructor() : this(null)
+
+    val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/ListSerializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/ListSerializer.kt
@@ -2,26 +2,18 @@ package be.osoc.team1.backend.util
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 /**
  * This class is used to serialize a list of [T] objects when it is used as a reference.
  * This makes sure it gets turned into a list containing their corresponding rest API urls.
  */
-open class ListSerializer<T>(private val genFunc: (T) -> String, t: Class<List<T>>?) : StdSerializer<List<T>>(t) {
-    constructor(func: (T) -> String) : this(func, null) {}
+open class ListSerializer<T>(private val genFunc: (T) -> String) : BaseSerializer<List<T>>() {
 
     override fun serialize(items: List<T>?, gen: JsonGenerator?, provider: SerializerProvider?) {
-        val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
         gen!!.writeStartArray()
         for (s in items!!) {
             gen.writeObject(baseUrl + genFunc(s))
         }
         gen.writeEndArray()
-    }
-
-    companion object {
-        private const val serialVersionUID = 1L
     }
 }

--- a/backend/src/main/kotlin/be/osoc/team1/backend/util/Serializer.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/util/Serializer.kt
@@ -2,22 +2,13 @@ package be.osoc.team1.backend.util
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 /**
  * This class is used to serialize a [T] object when it is used as a reference.
  * This makes sure it gets turned into the rest API url.
  */
-open class Serializer<T>(private val genFunc: (T) -> String, t: Class<T>?) : StdSerializer<T>(t) {
-    constructor(func: (T) -> String) : this(func, null) {}
+open class Serializer<T>(private val genFunc: (T) -> String) : BaseSerializer<T>() {
 
-    override fun serialize(item: T?, gen: JsonGenerator?, provider: SerializerProvider?) {
-        val baseUrl: String = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+    override fun serialize(item: T?, gen: JsonGenerator?, provider: SerializerProvider?) =
         gen!!.writeObject(baseUrl + genFunc(item!!))
-    }
-
-    companion object {
-        private const val serialVersionUID = 1L
-    }
 }


### PR DESCRIPTION
Moves small amounts of shared code between Serializer and ListSerializer into a BaseSerializer. The advantages of this are that the baseUrl code is now only in one location so if it's needs changing it only needs changing in one location. And the complicated constructor required by StdSerializer can be hidden in BaseSerializer.
```kotlin
open class Serializer<T>(private val genFunc: (T) -> String) : BaseSerializer<T>() {

    override fun serialize(item: T?, gen: JsonGenerator?, provider: SerializerProvider?) =
        gen!!.writeObject(baseUrl + genFunc(item!!))
}

open class ListSerializer<T>(private val genFunc: (T) -> String) : BaseSerializer<List<T>>() {

    override fun serialize(items: List<T>?, gen: JsonGenerator?, provider: SerializerProvider?) {
        gen!!.writeStartArray()
        for (s in items!!) {
            gen.writeObject(baseUrl + genFunc(s))
        }
        gen.writeEndArray()
    }
}
```