### PR TITLE
Add extra safety to status filter

### DIFF
--- a/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentControllerTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentControllerTests.kt
@@ -129,6 +129,8 @@ class StudentControllerTests(@Autowired private val mockMvc: MockMvc) {
             .andExpect(content().json(objectMapper.writeValueAsString(PagedCollection(allStudents, 4))))
         mockMvc.perform(get("$editionUrl?status=NonExistentStatus").principal(defaultPrincipal))
             .andExpect(status().isBadRequest)
+        mockMvc.perform(get("$editionUrl?status=Yes,No,Undecided,").principal(defaultPrincipal))
+            .andExpect(status().isBadRequest)
     }
 
     @Test


### PR DESCRIPTION
This pr makes `/students?status=Yes,No,Undecided,` return a 400 Bad request because of the trailing comma.