### PR TITLE
Update popscript + fix cascade

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
@@ -27,7 +27,7 @@ import javax.validation.constraints.NotBlank
  */
 @Entity
 class Position(
-    @ManyToOne(cascade = [CascadeType.PERSIST])
+    @ManyToOne(cascade = [CascadeType.ALL])
     val skill: Skill,
     val amount: Int,
     @JsonIgnore

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
@@ -123,7 +123,7 @@ class Student(
     @NotBlank
     val edition: String = "",
 
-    @ManyToMany(cascade = [CascadeType.PERSIST])
+    @ManyToMany(cascade = [CascadeType.ALL])
     @OrderBy
     val skills: Set<Skill> = sortedSetOf(),
     val alumn: Boolean = false,

--- a/docker/subpopulate.py
+++ b/docker/subpopulate.py
@@ -10,6 +10,11 @@ testerid = login["user"]["id"]
 
 authheaders = {'Authorization': f'Basic {token}',
                'Content-Type': 'application/json'}
+# activate edition
+requests.post('http://localhost:8080/api/editions',
+              headers=authheaders, json="ed")
+requests.post('http://localhost:8080/api/editions/ed/activate',
+              headers=authheaders)
 
 
 def make_student():
@@ -738,14 +743,10 @@ def make_student():
     }
 
 
-# requests.post('http://localhost:8080/api/ed/students',
-#               json=make_student(), headers={'Authorization': f'Basic {token}', 'Content-Type': 'application/json'})
-
 studentsids = []
 for _ in range(1000):
     studentsids.append(requests.post('http://localhost:8080/api/ed/students',
                                      json=make_student(), headers=authheaders).json()["id"])
-
 yes = requests.get('http://localhost:8080/api/ed/students',
                    headers=authheaders, params={"pageNumber": 0, "pageSize": 50, "sortBy": "id"}).json()["collection"]
 no = requests.get('http://localhost:8080/api/ed/students',


### PR DESCRIPTION
Updated the populate script and reverted cascade.PERSIST => cascade.ALL, this changed made it impossible to add new students or projects because of hibernate errors involving ids. This cascade option will need to be readded later because with cascade.ALL deletions of students or projects will cause a too long cascade of deletions.
