### PR TITLE
Fix cascade on Project positions and Student class skills

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
@@ -27,7 +27,7 @@ import javax.validation.constraints.NotBlank
  */
 @Entity
 class Position(
-    @ManyToOne(cascade = [CascadeType.ALL])
+    @ManyToOne(cascade = [CascadeType.MERGE])
     val skill: Skill,
     val amount: Int,
     @JsonIgnore

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
@@ -123,7 +123,7 @@ class Student(
     @NotBlank
     val edition: String = "",
 
-    @ManyToMany(cascade = [CascadeType.ALL])
+    @ManyToMany(cascade = [CascadeType.MERGE])
     @OrderBy
     val skills: Set<Skill> = sortedSetOf(),
     val alumn: Boolean = false,

--- a/backend/src/main/kotlin/be/osoc/team1/backend/services/ServicesUtil.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/services/ServicesUtil.kt
@@ -1,7 +1,5 @@
 package be.osoc.team1.backend.services
 
-import be.osoc.team1.backend.entities.StatusEnum
-
 private fun preprocess(string: String) = string.lowercase().replace(" ", "")
 
 /**
@@ -48,8 +46,6 @@ class Pager(val pageNumber: Int, val pageSize: Int) {
  * [PagedCollection] is a data class that holds a paginated [collection] and its pre-pagination length ([totalLength])
  */
 data class PagedCollection<T>(val collection: List<T>, val totalLength: Int)
-
-data class StudentFilter(val statusFilter: List<StatusEnum>, val nameQuery: String, val includeSuggested: Boolean)
 
 fun <T> List<T>.page(pager: Pager) = pager.paginate(this)
 

--- a/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
@@ -1,11 +1,15 @@
 package be.osoc.team1.backend.integrationtests
 
+import be.osoc.team1.backend.entities.Assignment
 import be.osoc.team1.backend.entities.Position
 import be.osoc.team1.backend.entities.Project
+import be.osoc.team1.backend.entities.Role
 import be.osoc.team1.backend.entities.Skill
 import be.osoc.team1.backend.entities.Student
+import be.osoc.team1.backend.entities.User
 import be.osoc.team1.backend.repositories.ProjectRepository
 import be.osoc.team1.backend.repositories.StudentRepository
+import be.osoc.team1.backend.repositories.UserRepository
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,10 +25,14 @@ class EntitySaveTests {
     @Autowired
     lateinit var projectRepository: ProjectRepository
 
+    @Autowired
+    lateinit var userRepository: UserRepository
+
     @AfterEach
     fun cleanup() {
-        studentRepository.deleteAll()
         projectRepository.deleteAll()
+        userRepository.deleteAll()
+        studentRepository.deleteAll()
     }
 
     @Test
@@ -45,25 +53,69 @@ class EntitySaveTests {
 
     @Test
     fun `test if saving a project with a new skill saves the new skill first`() {
+        val position = Position(Skill("test"), 2)
+        val student = Student("firstname", "lastname")
+        val user = User("username", "email", Role.Coach, "password")
+        studentRepository.save(student)
+        userRepository.save(user)
+
         val project = Project(
             "name", "clientName", "description",
-            positions = listOf(Position(Skill("test"), 2))
+                positions = listOf(position)
         )
+        /*
+         * We save the project before assigning students, this is how it is normally done in the application and it is
+         * a requirement because the Position objects need to exist in the database before attempting to save the
+         * assignments.
+         */
+        projectRepository.save(project)
+        project.assignments.add(Assignment(
+            student,
+            position,
+            user,
+            "reason"
+        ))
         projectRepository.save(project)
     }
 
     @Test
     fun `test if deleting a project with a shared skill doesn't cause issues`() {
+        val student = Student("firstname", "lastname")
+        val user = User("username", "email", Role.Coach, "password")
+        studentRepository.save(student)
+        userRepository.save(user)
+
         val skill = Skill("test")
+        val position1 = Position(skill, 2)
         val project1 = Project(
             "name", "clientName", "description",
-            positions = listOf(Position(skill, 2))
-        )
-        val project2 = Project(
-            "name", "clientName", "description",
-            positions = listOf(Position(skill, 2))
+            positions = listOf(position1),
         )
         projectRepository.save(project1)
+        project1.assignments.add(
+            Assignment(
+                student,
+                position1,
+                user,
+                "reason"
+            )
+        )
+        projectRepository.save(project1)
+
+        val position2 = Position(skill, 2)
+        val project2 = Project(
+            "name", "clientName", "description",
+            positions = listOf(position2),
+        )
+        projectRepository.save(project2)
+        project2.assignments.add(
+            Assignment(
+                student,
+                position2,
+                user,
+                "reason"
+            )
+        )
         projectRepository.save(project2)
         projectRepository.delete(project1)
     }

--- a/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
@@ -45,7 +45,8 @@ class EntitySaveTests {
 
     @Test
     fun `test if saving a project with a new skill saves the new skill first`() {
-        val project = Project("name", "clientName", "description",
+        val project = Project(
+            "name", "clientName", "description",
             positions = listOf(Position(Skill("test"), 2))
         )
         projectRepository.save(project)
@@ -54,10 +55,12 @@ class EntitySaveTests {
     @Test
     fun `test if deleting a project with a shared skill doesn't cause issues`() {
         val skill = Skill("test")
-        val project1 = Project("name", "clientName", "description",
+        val project1 = Project(
+            "name", "clientName", "description",
             positions = listOf(Position(skill, 2))
         )
-        val project2 = Project("name", "clientName", "description",
+        val project2 = Project(
+            "name", "clientName", "description",
             positions = listOf(Position(skill, 2))
         )
         projectRepository.save(project1)

--- a/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
@@ -1,0 +1,67 @@
+package be.osoc.team1.backend.integrationtests
+
+import be.osoc.team1.backend.entities.Position
+import be.osoc.team1.backend.entities.Project
+import be.osoc.team1.backend.entities.Skill
+import be.osoc.team1.backend.entities.Student
+import be.osoc.team1.backend.repositories.ProjectRepository
+import be.osoc.team1.backend.repositories.StudentRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class EntitySaveTests {
+    @Autowired
+    lateinit var studentRepository: StudentRepository
+
+    @Autowired
+    lateinit var projectRepository: ProjectRepository
+
+    @AfterEach
+    fun cleanup() {
+        studentRepository.deleteAll()
+        projectRepository.deleteAll()
+    }
+
+    @Test
+    fun `test if saving a student with a new skill saves the skill first`() {
+        val student = Student("firstname", "lastname", skills = sortedSetOf(Skill("test")))
+        studentRepository.save(student)
+    }
+
+    @Test
+    fun `test if deleting a student with a shared skill doesn't cause issues`() {
+        val skill = Skill("test")
+        val student1 = Student("firstname", "lastname", skills = sortedSetOf(skill))
+        val student2 = Student("firstname", "lastname", skills = sortedSetOf(skill))
+        studentRepository.save(student1)
+        studentRepository.save(student2)
+        studentRepository.delete(student1)
+    }
+
+    @Test
+    fun `test if saving a project with a new skill saves the new skill first`() {
+        val project = Project("name", "clientName", "description",
+            positions = listOf(Position(Skill("test"), 2))
+        )
+        projectRepository.save(project)
+    }
+
+    @Test
+    fun `test if deleting a project with a shared skill doesn't cause issues`() {
+        val skill = Skill("test")
+        val project1 = Project("name", "clientName", "description",
+            positions = listOf(Position(skill, 2))
+        )
+        val project2 = Project("name", "clientName", "description",
+            positions = listOf(Position(skill, 2))
+        )
+        projectRepository.save(project1)
+        projectRepository.save(project2)
+        projectRepository.delete(project1)
+    }
+}

--- a/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/integrationtests/EntitySaveTests.kt
@@ -61,7 +61,7 @@ class EntitySaveTests {
 
         val project = Project(
             "name", "clientName", "description",
-                positions = listOf(position)
+            positions = listOf(position)
         )
         /*
          * We save the project before assigning students, this is how it is normally done in the application and it is
@@ -69,12 +69,14 @@ class EntitySaveTests {
          * assignments.
          */
         projectRepository.save(project)
-        project.assignments.add(Assignment(
-            student,
-            position,
-            user,
-            "reason"
-        ))
+        project.assignments.add(
+            Assignment(
+                student,
+                position,
+                user,
+                "reason"
+            )
+        )
         projectRepository.save(project)
     }
 


### PR DESCRIPTION
This pull requests should fix the cascading of skills so that they are created if they do not exist yet but are kept upon deletion of a parent object(their might be multiple parent objects so the skill cannot be removed in that case because the other parents still need it).

We previously had merged something that should fix it but that solution didn't work and ended up causing even more issues so feel free to try this fix out and see if it doesn't break anything. Ideally we might want to try writing an integration test to make sure the issue doesn't come back in the future.