### PR TITLE
Fix aborted requests causing an IllegalStateException

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/security/AuthorizationFilter.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/security/AuthorizationFilter.kt
@@ -4,6 +4,7 @@ import be.osoc.team1.backend.security.TokenUtil.authenticateWithAccessToken
 import be.osoc.team1.backend.security.TokenUtil.decodeAndVerifyToken
 import be.osoc.team1.backend.security.TokenUtil.getAccessTokenFromRequest
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.catalina.connector.ClientAbortException
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.filter.OncePerRequestFilter
@@ -39,7 +40,10 @@ class AuthorizationFilter : OncePerRequestFilter() {
             }
             filterChain.doFilter(request, response)
         } catch (exception: Exception) {
-            respondException(response, exception)
+            when (exception) {
+                is ClientAbortException -> {}
+                else -> respondException(response, exception)
+            }
         }
     }
 


### PR DESCRIPTION
This PR closes #266.

As stated in the documentation:
"If the response has already been committed, this method throws an IllegalStateException. After using this method, the response should be considered to be committed and should not be written to."

The exception handler that is part of the auth system would catch the abort exception and attempt to handle it, I have currently fixed this by not doing anything special when receiving a `ClientAbortException`.