### PR TITLE
Optimize filterByNotYetAssigned

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Student.kt
@@ -189,4 +189,4 @@ fun List<Student>.filterByStudentCoach() = filter { it.possibleStudentCoach }
  * This function will filter a list of [Student]s to only return students who have not yet been assigned to a [Project].
  */
 fun List<Student>.filterByNotYetAssigned(assignmentRepository: AssignmentRepository) =
-    filter { assignmentRepository.findByStudent(it).isEmpty() }
+    this.toSet().subtract(assignmentRepository.findAll().map { it.student }.toSet()).toList()

--- a/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentControllerTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/unittests/StudentControllerTests.kt
@@ -243,8 +243,7 @@ class StudentControllerTests(@Autowired private val mockMvc: MockMvc) {
         val student2 = Student("firstname", "lastname")
         val studentList = listOf(student1, student2)
         every { studentService.getAllStudents(defaultSort, testEdition) } returns studentList
-        every { assignmentRepository.findByStudent(student1) } returns setOf(Assignment(student1, Position(Skill("Backend"), 1), User("username", "email", Role.Coach, "password"), "reason"))
-        every { assignmentRepository.findByStudent(student2) } returns setOf()
+        every { assignmentRepository.findAll() } returns setOf(Assignment(student1, Position(Skill("Backend"), 1), User("username", "email", Role.Coach, "password"), "reason"))
         mockMvc.perform(get("$editionUrl?unassignedOnly=false").principal(defaultPrincipal))
             .andExpect(status().isOk)
             .andExpect(content().json(objectMapper.writeValueAsString(PagedCollection(studentList, studentList.size))))


### PR DESCRIPTION
Closes #293.

This PR makes `filterByNotYetAssigned` a bit faster by drastically reducing the amount of required database calls. In a small test with ~1800 students, the delay of making the request and getting a reply back went from 850ms to 550ms.

We also planned to optimize `filterBySuggested` a bit as well, but we didn't really see a way of optimizing this in a way that would provide a meaningful performance benefit.