### PR TITLE
style: fix header styling

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -29,14 +29,14 @@ const Header: React.FC<HeaderProps> = () => {
         <ul className="m-0 p-0">
           <li
             className={`hover:underline sm:inline ${
-              current_path === '/students' ? 'underline' : ''
+              current_path.endsWith('/students') ? 'underline' : ''
             }`}
           >
             <Link href={`/${edition}/students`}>Select Students</Link>
           </li>
           <li
             className={`ml-3 hover:underline sm:inline ${
-              current_path === '/projects' ? 'underline' : ''
+              current_path.endsWith('/projects') ? 'underline' : ''
             }`}
           >
             <Link href={`/${edition}/projects`}>Projects</Link>


### PR DESCRIPTION
This PR fixes a bug where the header links styling wouldn't update correctly when using the new edition functionality.

Closes #269 