### PR TITLE
fix bug polling with small screen size

### DIFF
--- a/frontend/hooks/useOnScreen.ts
+++ b/frontend/hooks/useOnScreen.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState, useRef, RefObject } from 'react';
+
+export default function useOnScreen(ref: RefObject<HTMLElement>) {
+    const observerRef = useRef<IntersectionObserver | null>(null);
+    const [isOnScreen, setIsOnScreen] = useState(false);
+
+    useEffect(() => {
+        observerRef.current = new IntersectionObserver(([entry]) =>
+            setIsOnScreen(entry.isIntersecting)
+        );
+    }, []);
+
+    useEffect(() => {
+        if (observerRef.current && ref.current){
+            observerRef.current.observe(ref.current);
+
+            return () => {
+                if (observerRef.current){
+                    observerRef.current.disconnect();
+                }
+            };
+        }
+    }, [ref]);
+
+    return isOnScreen;
+}

--- a/frontend/pages/[editionName]/students.tsx
+++ b/frontend/pages/[editionName]/students.tsx
@@ -29,7 +29,7 @@ const Students: NextPage = () => {
     <RouteProtection allowedRoles={[UserRole.Admin, UserRole.Coach]}>
       <div className="min-w-screen flex min-h-screen flex-col items-center">
         <Header />
-        <DndProvider backend={HTML5Backend}>
+        <DndProvider backend={HTML5Backend} key={2}>
           <main className="flex w-full flex-row">
             {/* Holds the sidebar with search, filter and student results */}
             <section
@@ -41,7 +41,7 @@ const Students: NextPage = () => {
               <div
                 className={`${
                   showSidebar ? 'visible' : 'hidden'
-                } absolute left-[24px] top-[17px] flex flex-col justify-center text-[29px] opacity-20 md:hidden`}
+                } absolute left-[24px] top-[16px] flex flex-col justify-center text-[30px] opacity-20 md:hidden z-50`}
               >
                 <i onClick={() => setShowSidebar(!showSidebar)}>{arrow_in}</i>
               </div>


### PR DESCRIPTION
There was a bug when studentsidebar is hidden on small screen size, polling would load an extra page every time, leading to large overhead and lag. This is now fixed by first checking if what is being polled is actually visible on the screen.