### PR TITLE
fix polling projects bug

### DIFF
--- a/frontend/components/projects/ProjectTile.tsx
+++ b/frontend/components/projects/ProjectTile.tsx
@@ -455,15 +455,17 @@ const ProjectTile: React.FC<ProjectProp> = ({
 
       {/* assigned students list */}
       <div className="flex flex-col">
-        {myProject.assignments.map((assignment) => (
-          <ProjectAssignmentsList
-            key={assignment.id}
-            assignment={assignment}
-            setOpenUnassignment={setOpenUnassignment}
-            setAssignmentId={setAssignmentId}
-            setRemoveStudentName={setRemoveStudentName}
-          />
-        ))}
+        {myProject.assignments
+          .sort((one, two) => (one > two ? -1 : 1))
+          .map((assignment) => (
+            <ProjectAssignmentsList
+              key={assignment.id}
+              assignment={assignment}
+              setOpenUnassignment={setOpenUnassignment}
+              setAssignmentId={setAssignmentId}
+              setRemoveStudentName={setRemoveStudentName}
+            />
+          ))}
       </div>
 
       {loading && (

--- a/frontend/hooks/useOnScreen.ts
+++ b/frontend/hooks/useOnScreen.ts
@@ -17,15 +17,13 @@ export default function useOnScreen(ref: RefObject<HTMLElement>) {
 
   useEffect(() => {
     if (observerRef.current && ref.current) {
-      observerRef.current.observe(ref.current);
+      observerRef.current?.observe(ref.current);
 
       return () => {
-        if (observerRef.current) {
-          observerRef.current.disconnect();
-        }
+        observerRef.current?.disconnect();
       };
     }
-  }, [ref]);
+  }, [ref.current]);
 
   return isOnScreen;
 }

--- a/frontend/hooks/useOnScreen.ts
+++ b/frontend/hooks/useOnScreen.ts
@@ -17,7 +17,7 @@ export default function useOnScreen(ref: RefObject<HTMLElement>) {
 
   useEffect(() => {
     if (observerRef.current && ref.current) {
-      observerRef.current?.observe(ref.current);
+      observerRef.current.observe(ref.current);
 
       return () => {
         observerRef.current?.disconnect();

--- a/frontend/pages/[editionName]/projects.tsx
+++ b/frontend/pages/[editionName]/projects.tsx
@@ -115,8 +115,8 @@ const Projects: NextPage = () => {
   const [projectForm, setProjectForm] = useState(
     JSON.parse(JSON.stringify({ ...defaultprojectForm }))
   );
-  const elementRef = useRef(null);
-  const isOnScreen = useOnScreen(elementRef);
+  const elementRef1 = useRef<HTMLDivElement>(null);
+  const isOnScreen = useOnScreen(elementRef1);
 
   let controller = new AbortController();
   useAxiosAuth();
@@ -291,7 +291,6 @@ const Projects: NextPage = () => {
 
             {/* Holds the projects searchbar + project tiles */}
             <section
-              ref={elementRef}
               className={`${
                 showSidebar ? 'hidden' : 'visible'
               } mt-[30px] w-full md:visible md:block`}
@@ -310,6 +309,7 @@ const Projects: NextPage = () => {
 
                 <div
                   className={`flex w-full flex-row justify-center xl:mr-8 xl1920:mr-10`}
+                  ref={elementRef1}
                 >
                   {/* TODO add an easy reset/undo search button */}
                   {/* TODO either move search icon left and add xmark to the right or vice versa */}


### PR DESCRIPTION
There was a bug with projects polling not actually polling if the onscreen hook was called before the render was done.
This is now fixed.
I also added a sort to the assignments pre-render since those had some weird flickering behavior otherwise.