### PR TITLE
Fix positions on new projects and status suggestions having a blank edition field

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/controllers/ProjectController.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/controllers/ProjectController.kt
@@ -1,7 +1,6 @@
 package be.osoc.team1.backend.controllers
 
 import be.osoc.team1.backend.entities.Assignment
-import be.osoc.team1.backend.entities.Position
 import be.osoc.team1.backend.entities.Project
 import be.osoc.team1.backend.entities.Student
 import be.osoc.team1.backend.entities.User
@@ -79,11 +78,11 @@ class ProjectController(private val service: ProjectService) {
         @RequestBody projectRegistration: Project,
         @PathVariable edition: String
     ): ResponseEntity<Project> {
-        val positions = projectRegistration.positions.map { Position(it.skill, it.amount, edition) }
+        projectRegistration.positions.forEach { it.edition = edition }
         val project = Project(
             projectRegistration.name, projectRegistration.description, projectRegistration.clientName,
             edition,
-            projectRegistration.coaches, positions, projectRegistration.assignments
+            projectRegistration.coaches, projectRegistration.positions, projectRegistration.assignments
         )
         val createdProject = service.postProject(project)
         return getObjectCreatedResponse(createdProject.id, createdProject)
@@ -116,6 +115,7 @@ class ProjectController(private val service: ProjectService) {
         @PathVariable edition: String,
         @RequestBody project: Project
     ): ResponseEntity<Project> {
+        project.positions.forEach { it.edition = edition }
         if (projectId != project.id)
             throw FailedOperationException("Request url id=\"$projectId\" did not match request body id=\"${project.id}\"")
 

--- a/backend/src/main/kotlin/be/osoc/team1/backend/controllers/ProjectController.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/controllers/ProjectController.kt
@@ -1,6 +1,7 @@
 package be.osoc.team1.backend.controllers
 
 import be.osoc.team1.backend.entities.Assignment
+import be.osoc.team1.backend.entities.Position
 import be.osoc.team1.backend.entities.Project
 import be.osoc.team1.backend.entities.Student
 import be.osoc.team1.backend.entities.User
@@ -78,10 +79,11 @@ class ProjectController(private val service: ProjectService) {
         @RequestBody projectRegistration: Project,
         @PathVariable edition: String
     ): ResponseEntity<Project> {
+        val positions = projectRegistration.positions.map { Position(it.skill, it.amount, edition) }
         val project = Project(
             projectRegistration.name, projectRegistration.description, projectRegistration.clientName,
             edition,
-            projectRegistration.coaches, projectRegistration.positions, projectRegistration.assignments
+            projectRegistration.coaches, positions, projectRegistration.assignments
         )
         val createdProject = service.postProject(project)
         return getObjectCreatedResponse(createdProject.id, createdProject)

--- a/backend/src/main/kotlin/be/osoc/team1/backend/controllers/StudentController.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/controllers/StudentController.kt
@@ -167,10 +167,10 @@ class StudentController(
         service.setStudentStatus(studentId, status, edition)
 
     /**
-     * Add a [statusSuggestion] to the student with the given [studentId]. The suggester field should
+     * Add a [statusSuggestionRegistration] to the student with the given [studentId]. The suggester field should
      * be equal to the coach who is making this suggestion, so equal to the currently authenticated user.
      * If the suggester does not match the currently authenticated user a '401: Unauthorized" is returned. The
-     * [statusSuggestion] should be passed in the request body as a JSON object and should have the
+     * [statusSuggestionRegistration] should be passed in the request body as a JSON object and should have the
      * following format:
      *
      * ```
@@ -191,10 +191,16 @@ class StudentController(
     @SecuredEdition
     fun addStudentStatusSuggestion(
         @PathVariable studentId: UUID,
-        @RequestBody statusSuggestion: StatusSuggestion,
+        @RequestBody statusSuggestionRegistration: StatusSuggestion,
         @PathVariable edition: String,
         principal: Principal,
     ) {
+        val statusSuggestion = StatusSuggestion(
+            statusSuggestionRegistration.suggester,
+            statusSuggestionRegistration.status,
+            statusSuggestionRegistration.motivation,
+            edition
+        )
         val user = userDetailService.getUserFromPrincipal(principal)
         if (statusSuggestion.suggester != user)
             throw UnauthorizedOperationException("The 'coachId' did not equal authenticated user id!")

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Project.kt
@@ -32,7 +32,7 @@ class Position(
     val amount: Int,
     @JsonIgnore
     @NotBlank
-    val edition: String = ""
+    var edition: String = ""
 ) {
     @Id
     val id: UUID = UUID.randomUUID()


### PR DESCRIPTION
When testing the frontend after we added the edition security annotation, I noticed that the fronted could not fetch project positions, this because the position fields were set to the default value and not the same value as the project edition. This PR fixes that by mapping over the positions from the `projectRegistration` and creating a new position with the edition field set correctly.