### PR TITLE
remove dialect from properties

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,7 +4,6 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL81Dialect
 spring.jpa.generate-ddl=true
 server.servlet.context-path=/api
 


### PR DESCRIPTION
This removes the dialect line from the backend properties file since this gave issues with deployment to the server.
I tested this locally using a brand new docker container and everything seems to work fine.

NOTE: if you remove this dialect rule, you'll probably have to create a new database since there is an error with ```ERROR: operator does not exist: uuid = bytea``` that apparently changes between using the 8.1 dialect or using the auto discover. 