### PR TITLE
fix edition field empty on post communication

### DIFF
--- a/backend/src/main/kotlin/be/osoc/team1/backend/controllers/CommunicationController.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/controllers/CommunicationController.kt
@@ -44,6 +44,7 @@ class CommunicationController(
         @PathVariable edition: String,
         @RequestBody communication: Communication
     ): ResponseEntity<Communication> {
+        communication.edition = edition
         val createdCommunication = communicationService.createCommunication(communication)
         studentService.addCommunicationToStudent(studentId, communication, edition)
         return getObjectCreatedResponse(createdCommunication.id, createdCommunication)

--- a/backend/src/main/kotlin/be/osoc/team1/backend/controllers/CommunicationController.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/controllers/CommunicationController.kt
@@ -42,9 +42,10 @@ class CommunicationController(
     fun createCommunication(
         @PathVariable studentId: UUID,
         @PathVariable edition: String,
-        @RequestBody communication: Communication
+        @RequestBody communicationRegister: Communication
     ): ResponseEntity<Communication> {
-        communication.edition = edition
+        val communication =
+            Communication(communicationRegister.message, communicationRegister.type, communicationRegister.edition)
         val createdCommunication = communicationService.createCommunication(communication)
         studentService.addCommunicationToStudent(studentId, communication, edition)
         return getObjectCreatedResponse(createdCommunication.id, createdCommunication)

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
@@ -20,7 +20,7 @@ class Communication(
     val type: CommunicationTypeEnum,
     @JsonIgnore
     @NotBlank
-    var edition: String = ""
+    val edition: String = ""
 ) {
     @Id
     var id: UUID = UUID.randomUUID()

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
@@ -20,7 +20,7 @@ class Communication(
     val type: CommunicationTypeEnum,
     @JsonIgnore
     @NotBlank
-    val edition: String = ""
+    var edition: String = ""
 ) {
     @Id
     var id: UUID = UUID.randomUUID()


### PR DESCRIPTION
This closes #345 by changing communication edition field to var and setting it on the post endpoint.

Won't be merging this until a backend person has actually checked this, also, if you are a backend person and want to make changes to this, please push them, no need to ask.

This still needs a check to see if the given edition exists (and is active), probably somewhere in the service?