### PR TITLE
Infinite list fix

### DIFF
--- a/frontend/components/InfiniteList.tsx
+++ b/frontend/components/InfiniteList.tsx
@@ -1,59 +1,61 @@
-import {useEffect, useRef, useState} from "react";
-import useOnScreen from "../hooks/useOnScreen";
-import {SpinnerCircular} from "spinners-react";
+import { useEffect, useRef, useState } from 'react';
+import useOnScreen from '../hooks/useOnScreen';
+import { SpinnerCircular } from 'spinners-react';
 
 type InfiniteListProps<Type> = {
-    list: Type[];
-    renderItem: (student: Type) => JSX.Element;
-    renderWhenEmpty: string;
-    hasMoreItems: boolean;
-    loading: boolean;
-    loadMoreItems: () => void;
-}
+  list: Type[];
+  renderItem: (student: Type) => JSX.Element;
+  loadingText: string;
+  hasMoreItems: boolean;
+  loading: boolean;
+  loadMoreItems: () => void;
+};
 
 const InfiniteList: React.FC<InfiniteListProps<any>> = ({
-    list,
-    renderItem, renderWhenEmpty, hasMoreItems, loadMoreItems, loading
+  list,
+  renderItem,
+  loadingText,
+  hasMoreItems,
+  loadMoreItems,
+  loading,
 }: InfiniteListProps<any>) => {
-    const elementRef = useRef<HTMLDivElement>(null);
-    const isOnScreen = useOnScreen(elementRef);
-    const [fetching, setFetching] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
+  const isOnScreen = useOnScreen(elementRef);
+  const [fetching, setFetching] = useState(false);
 
-    useEffect(() => {
-        console.log(' ' + { isOnScreen }.isOnScreen + ' ' + !fetching + ' '  + hasMoreItems + ' ' + !loading)
-        if ({ isOnScreen }.isOnScreen && !fetching && hasMoreItems && !loading){
-            setFetching(true);
-            (async () => {
-                console.log("calling load more items");
-                loadMoreItems();
-                await new Promise(f => setTimeout(f, 1500));
-                setFetching(false);
-            })();
+  /**
+   * This checks if we need to load more items
+   * To avoid accidental multi-loads, we wait 1.5 seconds between loads
+   */
+  useEffect(() => {
+    if ({ isOnScreen }.isOnScreen && !fetching && hasMoreItems && !loading) {
+      setFetching(true);
+      (async () => {
+        loadMoreItems();
+        await new Promise((f) => setTimeout(f, 1500));
+        setFetching(false);
+      })();
+    }
+  }, [isOnScreen, { isOnScreen }.isOnScreen, fetching, hasMoreItems, loading]);
 
-        }
-    }, [isOnScreen, { isOnScreen }.isOnScreen, fetching, hasMoreItems, loading])
-
-    return (
-        <div>
-            {list.map((item) => renderItem(item))}
-            {/*{hasMoreItems && <div ref={elementRef}>Loading more items</div>}*/}
-            <div
-                ref={elementRef}
-                className={`${
-                    hasMoreItems ? 'visible block' : 'hidden'
-                } text-center`}
-            >
-                <p>{renderWhenEmpty}</p>
-                <SpinnerCircular
-                    size={30}
-                    thickness={100}
-                    color="#FCB70F"
-                    secondaryColor="rgba(252, 183, 15, 0.4)"
-                    className="mx-auto"
-                />
-            </div>
-        </div>
-    );
-}
+  return (
+    <div>
+      {list.map((item) => renderItem(item))}
+      <div
+        ref={elementRef}
+        className={`${hasMoreItems ? 'visible block' : 'hidden'} text-center`}
+      >
+        <p>{loadingText}</p>
+        <SpinnerCircular
+          size={30}
+          thickness={100}
+          color="#FCB70F"
+          secondaryColor="rgba(252, 183, 15, 0.4)"
+          className="mx-auto"
+        />
+      </div>
+    </div>
+  );
+};
 
 export default InfiniteList;

--- a/frontend/components/InfiniteList.tsx
+++ b/frontend/components/InfiniteList.tsx
@@ -11,6 +11,8 @@ type InfiniteListProps<Type> = {
   loadMoreItems: () => void;
 };
 
+// I don't know how to fix these any types to follow the template type
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 const InfiniteList: React.FC<InfiniteListProps<any>> = ({
   list,
   renderItem,

--- a/frontend/components/InfiniteList.tsx
+++ b/frontend/components/InfiniteList.tsx
@@ -1,0 +1,59 @@
+import {useEffect, useRef, useState} from "react";
+import useOnScreen from "../hooks/useOnScreen";
+import {SpinnerCircular} from "spinners-react";
+
+type InfiniteListProps<Type> = {
+    list: Type[];
+    renderItem: (student: Type) => JSX.Element;
+    renderWhenEmpty: string;
+    hasMoreItems: boolean;
+    loading: boolean;
+    loadMoreItems: () => void;
+}
+
+const InfiniteList: React.FC<InfiniteListProps<any>> = ({
+    list,
+    renderItem, renderWhenEmpty, hasMoreItems, loadMoreItems, loading
+}: InfiniteListProps<any>) => {
+    const elementRef = useRef<HTMLDivElement>(null);
+    const isOnScreen = useOnScreen(elementRef);
+    const [fetching, setFetching] = useState(false);
+
+    useEffect(() => {
+        console.log(' ' + { isOnScreen }.isOnScreen + ' ' + !fetching + ' '  + hasMoreItems + ' ' + !loading)
+        if ({ isOnScreen }.isOnScreen && !fetching && hasMoreItems && !loading){
+            setFetching(true);
+            (async () => {
+                console.log("calling load more items");
+                loadMoreItems();
+                await new Promise(f => setTimeout(f, 1500));
+                setFetching(false);
+            })();
+
+        }
+    }, [isOnScreen, { isOnScreen }.isOnScreen, fetching, hasMoreItems, loading])
+
+    return (
+        <div>
+            {list.map((item) => renderItem(item))}
+            {/*{hasMoreItems && <div ref={elementRef}>Loading more items</div>}*/}
+            <div
+                ref={elementRef}
+                className={`${
+                    hasMoreItems ? 'visible block' : 'hidden'
+                } text-center`}
+            >
+                <p>{renderWhenEmpty}</p>
+                <SpinnerCircular
+                    size={30}
+                    thickness={100}
+                    color="#FCB70F"
+                    secondaryColor="rgba(252, 183, 15, 0.4)"
+                    className="mx-auto"
+                />
+            </div>
+        </div>
+    );
+}
+
+export default InfiniteList;

--- a/frontend/components/projects/ProjectPopup.tsx
+++ b/frontend/components/projects/ProjectPopup.tsx
@@ -475,7 +475,7 @@ const ProjectPopup: React.FC<ProjectPopupProp> = ({
                       setPositionDropdownValue(
                         index,
                         e
-                          ? { value: ' ', label: e }
+                          ? { value: e, label: e }
                           : ({} as { value: string; label: string })
                       );
                     }}

--- a/frontend/hooks/useOnScreen.ts
+++ b/frontend/hooks/useOnScreen.ts
@@ -23,7 +23,7 @@ export default function useOnScreen(ref: RefObject<HTMLElement>) {
         observerRef.current?.disconnect();
       };
     }
-  }, [ref.current]);
+  }, [ref, ref.current]);
 
   return isOnScreen;
 }


### PR DESCRIPTION
I would really like for everyone to check if they can get any more weird behaviour out of the students list now since after looking at this for hours I might have missed another (new) bug.

This pr stops using flatlist for the student sidebar since I'm pretty certain it either has a bug, 
or the frontend code is doing something weird and I have no clue what happens to cause the problem.

The issue is that the infinite list does not update correctly after you've un-selected all possible student statusses and then select one or more again, the scrolling state either gets locked at the top or bottom, or jumps around all the time. This seems due to the element at the bottom of the list, that is used to check if new elements should be loaded, constantly switching from visible to hidden (10 per second at least) and I wasn't able to find out why this happened.

This is an implementation doing the exact same thing as the original infinite scroll list, but without whatever weird stuff it does.
This also seems to be a lot faster and has no scroll bar lag, probably due to us not needing any of the extra options that came with the original flatlist import.

I only changed this in the studentsidebar since the project list won't ever be big enough to have this problem and I don't want to waste any more time on this.

Note, I won't be merging this before #365 is merged to avoid merge conflicts