### PR TITLE
Adjust login page styling

### DIFF
--- a/frontend/pages/forgotPassword/[forgotPasswordToken].tsx
+++ b/frontend/pages/forgotPassword/[forgotPasswordToken].tsx
@@ -82,13 +82,14 @@ const ForgotPassword: NextPage = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             New Password
             <input
-              className={`mt-1 box-border block h-8 w-full border-2 ${
+              className={`mt-1 block h-8 w-full rounded border ${
                 validPassword || password.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
               } p-1 text-sm`}
               name="password"
               type="password"
+              placeholder="password"
               minLength={8}
               maxLength={64}
               {...passwordProps}
@@ -96,7 +97,7 @@ const ForgotPassword: NextPage = () => {
             />
           </label>
           <button
-            className="rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-4"
+            className="rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-4 hover:brightness-95"
             type="submit"
           >
             Change password

--- a/frontend/pages/forgotPassword/index.tsx
+++ b/frontend/pages/forgotPassword/index.tsx
@@ -71,16 +71,17 @@ const ForgotPassword: NextPage = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-8 lg:max-w-sm">
             Email Address
             <input
-              className="mt-1 box-border block h-8 w-full border-2 border-[#C4C4C4] p-1 text-sm"
+              className="mt-1 block h-8 w-full rounded border border-[#C4C4C4] p-1 text-sm"
               name="email"
               type="email"
+              placeholder="you@example.com"
               {...emailProps}
               ref={emailRef}
               required
             />
           </label>
           <button
-            className="rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-4"
+            className="rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-4 hover:brightness-95"
             type="submit"
           >
             Change password

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -108,7 +108,7 @@ const Login = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-8 lg:max-w-sm">
             Email Address
             <input
-              className="mt-1 block h-8 w-full rounded border border-2 border-[#C4C4C4] p-1 text-sm"
+              className="mt-1 block h-8 w-full rounded border border-[#C4C4C4] p-1 text-sm"
               name="email"
               type="email"
               placeholder="you@example.com"
@@ -124,7 +124,7 @@ const Login = () => {
               </p>
             </Link>
             <input
-              className="mt-1 block h-8 w-full rounded border border-2 border-[#C4C4C4] p-1 text-sm"
+              className="mt-1 block h-8 w-full rounded border border-[#C4C4C4] p-1 text-sm"
               name="password"
               type="password"
               placeholder="password"

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -108,9 +108,10 @@ const Login = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-8 lg:max-w-sm">
             Email Address
             <input
-              className="mt-1 box-border block h-8 w-full border-2 border-[#C4C4C4] p-1 text-sm"
+              className="mt-1 block h-8 w-full rounded border border-2 border-[#C4C4C4] p-1 text-sm"
               name="email"
               type="email"
+              placeholder="you@example.com"
               {...emailProps}
               ref={emailRef}
             />
@@ -123,15 +124,16 @@ const Login = () => {
               </p>
             </Link>
             <input
-              className="mt-1 box-border block h-8 w-full border-2 border-[#C4C4C4] p-1 text-sm"
+              className="mt-1 block h-8 w-full rounded border border-2 border-[#C4C4C4] p-1 text-sm"
               name="password"
               type="password"
+              placeholder="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
           </label>
           <button
-            className="m-auto block rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-4"
+            className="m-auto block rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 hover:brightness-95 lg:mb-4"
             type="submit"
           >
             Log in

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -91,7 +91,7 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Name
             <input
-              className={`mt-1 box-border block h-8 w-full border-2 ${
+              className={`mt-1 box-border block h-8 w-full rounded border border-2 ${
                 validName || name.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
@@ -105,7 +105,7 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Email Address
             <input
-              className={`mt-1 box-border block h-8 w-full border-2 ${
+              className={`mt-1 block h-8 w-full rounded border border-2 ${
                 validEmail || email.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
@@ -118,7 +118,7 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Password
             <input
-              className={`mt-1 box-border block h-8 w-full border-2 ${
+              className={`mt-1 block h-8 w-full rounded border border-2 ${
                 validPassword || password.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
@@ -133,7 +133,7 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Repeat Password
             <input
-              className={`mt-1 box-border block h-8 w-full border-2 ${
+              className={`mt-1 block h-8 w-full rounded border border-2 ${
                 validMatch || match.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
@@ -146,13 +146,13 @@ const register = () => {
             />
           </label>
           <button
-            className="rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 lg:mb-3"
+            className="m-auto block rounded-sm bg-osoc-btn-primary px-4 py-1 font-medium text-osoc-blue shadow-sm shadow-gray-300 hover:brightness-95 lg:mb-3"
             type="submit"
           >
             Register
           </button>
           <Link href="/login">
-            <p className="m-auto w-fit text-xs underline underline-offset-1 opacity-90 hover:cursor-pointer">
+            <p className="mt-2 inline-block text-xs underline underline-offset-1 opacity-90 hover:cursor-pointer">
               back to login
             </p>
           </Link>

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -91,13 +91,14 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Name
             <input
-              className={`mt-1 box-border block h-8 w-full rounded border border-2 ${
+              className={`mt-1 box-border block h-8 w-full rounded border ${
                 validName || name.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
               } p-1 text-sm`}
               name="name"
               type="text"
+              placeholder="John Doe"
               ref={nameRef}
               {...nameProps}
             />
@@ -105,26 +106,28 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Email Address
             <input
-              className={`mt-1 block h-8 w-full rounded border border-2 ${
+              className={`mt-1 block h-8 w-full rounded border ${
                 validEmail || email.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
               } p-1 text-sm`}
               name="email"
               type="email"
+              placeholder="you@example.com"
               {...emailProps}
             />
           </label>
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Password
             <input
-              className={`mt-1 block h-8 w-full rounded border border-2 ${
+              className={`mt-1 block h-8 w-full rounded border ${
                 validPassword || password.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
               } p-1 text-sm`}
               name="password"
               type="password"
+              placeholder="placeholder"
               minLength={8}
               maxLength={64}
               {...passwordProps}
@@ -133,13 +136,14 @@ const register = () => {
           <label className="mx-auto mb-4 block text-left lg:mb-4 lg:max-w-sm">
             Repeat Password
             <input
-              className={`mt-1 block h-8 w-full rounded border border-2 ${
+              className={`mt-1 block h-8 w-full rounded border ${
                 validMatch || match.length === 0
                   ? 'border-[#C4C4C4]'
                   : 'border-red-500'
               } p-1 text-sm`}
               name="repeatPassword"
               type="password"
+              placeholder="placeholder"
               minLength={8}
               maxLength={64}
               {...matchProps}


### PR DESCRIPTION
This PR slightly adjusts styling on the login/register/forgot password pages to use round text boxes that have a thinner border and to add a hover effect on the buttons to make the UI feel more responsive.