### PR TITLE
Small studentsidebar stile adjustments

### DIFF
--- a/frontend/components/students/StudentTile.tsx
+++ b/frontend/components/students/StudentTile.tsx
@@ -90,7 +90,7 @@ const StudentTile: React.FC<StudentProp> = ({
       onClick={() => setStudentBase(myStudent)}
     >
       <div
-        className={`my-4 mx-1 flex flex-row justify-between p-2 opacity-100 shadow-sm shadow-gray-500 hover:bg-osoc-neutral-bg hover:brightness-75 cursor-pointer`}
+        className={`my-4 mx-1 flex cursor-pointer flex-row justify-between p-2 opacity-100 shadow-sm shadow-gray-500 hover:bg-osoc-neutral-bg hover:brightness-75`}
       >
         {/* basic student info */}
         <div className="flex w-3/4 flex-col justify-center">

--- a/frontend/components/students/StudentTile.tsx
+++ b/frontend/components/students/StudentTile.tsx
@@ -90,7 +90,7 @@ const StudentTile: React.FC<StudentProp> = ({
       onClick={() => setStudentBase(myStudent)}
     >
       <div
-        className={`my-4 mx-1 flex flex-row justify-between p-2 opacity-100 shadow-sm shadow-gray-500`}
+        className={`my-4 mx-1 flex flex-row justify-between p-2 opacity-100 shadow-sm shadow-gray-500 hover:bg-osoc-neutral-bg hover:brightness-75 cursor-pointer`}
       >
         {/* basic student info */}
         <div className="flex w-3/4 flex-col justify-center">


### PR DESCRIPTION
This tiny PR makes it so hovering over a student tile changes it colour slightly and makes it use the pointer cursor. This makes it clear it is clickable/draggable and the change of colour also makes it feel more responsive.
