### PR TITLE
Improve communications page

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>jackson-module-kotlin</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
 		</dependency>

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
@@ -1,7 +1,7 @@
 package be.osoc.team1.backend.entities
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import java.time.LocalDateTime
+import java.util.Date
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -26,7 +26,7 @@ class Communication(
     @JsonIgnore
     @OneToOne
     val student: Student,
-    val registrationTime: LocalDateTime = LocalDateTime.now()
+    val registrationTime: Date = Date()
 ) {
     @Id
     var id: UUID = UUID.randomUUID()

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
@@ -1,6 +1,7 @@
 package be.osoc.team1.backend.entities
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -24,7 +25,8 @@ class Communication(
     val edition: String = "",
     @JsonIgnore
     @OneToOne
-    val student: Student
+    val student: Student,
+    val registrationTime: LocalDateTime = LocalDateTime.now()
 ) {
     @Id
     var id: UUID = UUID.randomUUID()

--- a/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
+++ b/backend/src/main/kotlin/be/osoc/team1/backend/entities/Communication.kt
@@ -14,7 +14,9 @@ enum class CommunicationTypeEnum {
 
 /**
  * Represents communication in the database. Communication is constructed with a [type] and a [message]
- * Note that neither of these fields, nor the combination of both of them need to be unique.
+ * Note that neither of these fields, nor the combination of both of them need to be unique. When creating a
+ * communication, it will also get a [registrationTime], you can pass this as a parameter or use the default value which
+ * will just set the [registrationTime] to the current time.
  */
 @Entity
 class Communication(

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL81Dialect
 spring.jpa.generate-ddl=true
 server.servlet.context-path=/api
 
@@ -11,3 +12,5 @@ server.error.include-message=always
 server.error.include-binding-errors=always
 server.error.include-stacktrace=on_param
 server.error.include-exception=false
+
+spring.jackson.serialization.write_dates_as_timestamps=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,7 +4,6 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL81Dialect
 spring.jpa.generate-ddl=true
 server.servlet.context-path=/api
 

--- a/backend/src/test/kotlin/be/osoc/team1/backend/unittests/CommunicationControllerTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/unittests/CommunicationControllerTests.kt
@@ -14,6 +14,7 @@ import be.osoc.team1.backend.services.EditionService
 import be.osoc.team1.backend.services.OsocUserDetailService
 import be.osoc.team1.backend.services.StudentService
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.Runs
 import io.mockk.every
@@ -62,7 +63,7 @@ class CommunicationControllerTests(@Autowired private val mockMvc: MockMvc) {
     private val testEdition = "testEdition"
     private val editionUrl = "/$testEdition/communications"
     private val testCommunication = Communication("test message", CommunicationTypeEnum.Email, testEdition, testStudent)
-    private val objectMapper = ObjectMapper()
+    private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
     private val jsonRepresentation = objectMapper.writeValueAsString(testCommunication)
     private val jsonRepresentationDTO = objectMapper.writeValueAsString(CommunicationDTO("test message", CommunicationTypeEnum.Email))
 

--- a/backend/src/test/kotlin/be/osoc/team1/backend/unittests/CommunicationControllerTests.kt
+++ b/backend/src/test/kotlin/be/osoc/team1/backend/unittests/CommunicationControllerTests.kt
@@ -14,7 +14,6 @@ import be.osoc.team1.backend.services.EditionService
 import be.osoc.team1.backend.services.OsocUserDetailService
 import be.osoc.team1.backend.services.StudentService
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.Runs
 import io.mockk.every
@@ -63,7 +62,7 @@ class CommunicationControllerTests(@Autowired private val mockMvc: MockMvc) {
     private val testEdition = "testEdition"
     private val editionUrl = "/$testEdition/communications"
     private val testCommunication = Communication("test message", CommunicationTypeEnum.Email, testEdition, testStudent)
-    private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+    private val objectMapper = ObjectMapper()
     private val jsonRepresentation = objectMapper.writeValueAsString(testCommunication)
     private val jsonRepresentationDTO = objectMapper.writeValueAsString(CommunicationDTO("test message", CommunicationTypeEnum.Email))
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -7,3 +7,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect
 spring.jpa.generate-ddl=true
 server.servlet.context-path=/api
+
+spring.jackson.serialization.write_dates_as_timestamps=true

--- a/docs/osoc.yaml
+++ b/docs/osoc.yaml
@@ -931,7 +931,8 @@ paths:
             summary: Add a new communication with a student
             description: |
                 Add a communication to the database.
-                The created communication object is returned.
+                The created communication object is returned. This created object contains the id of this new object and
+                the registrationTime alongside the message and type which were provided in the request.
             parameters:
                 -   name: studentId
                     required: true

--- a/frontend/components/communications/CommsCreationPopup.tsx
+++ b/frontend/components/communications/CommsCreationPopup.tsx
@@ -134,7 +134,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
                 Cancel
               </button>
               <button
-                className="col-span-1 col-start-3 col-end-4 bg-check-green px-3 py-1 disabled:bg-green-200 disabled:text-gray-400 rounded-sm hover:brightness-95"
+                className="col-span-1 col-start-3 col-end-4 bg-check-green px-3 py-1 disabled:bg-green-200 disabled:text-gray-400 rounded-sm hover:brightness-95 disabled:brightness-100 disabled:cursor-not-allowed"
                 type="submit"
                 disabled={!student || !message}
               >

--- a/frontend/components/communications/CommsCreationPopup.tsx
+++ b/frontend/components/communications/CommsCreationPopup.tsx
@@ -84,7 +84,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
               className="grid grid-cols-4 justify-items-center gap-y-2"
               onSubmit={submit}
             >
-              <label className="col-span-4 w-11/12 pl-2">
+              <label className="col-span-4 w-full px-5">
                 Student
                 <Select
                   className="mt-1"
@@ -114,11 +114,11 @@ const CommsCreationPopup: FC<CCPProps> = ({
                   })}
                 />
               </label>
-              <label className="col-span-4 w-11/12 pl-2">
+              <label className="col-span-4 w-full px-5">
                 Information
                 <textarea
                   placeholder="Communication Information"
-                  className="mx-2 mt-1 w-full ml-0 resize-y border-2 px-1 min-h-[150px]"
+                  className="mx-2 mt-1 w-full ml-0 resize-y rounded border px-1 min-h-[150px]"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                 />

--- a/frontend/components/communications/CommsCreationPopup.tsx
+++ b/frontend/components/communications/CommsCreationPopup.tsx
@@ -118,13 +118,13 @@ const CommsCreationPopup: FC<CCPProps> = ({
                 Information
                 <textarea
                   placeholder="Communication Information"
-                  className="mx-2 mt-1 w-full ml-0 resize-y rounded border px-1 min-h-[150px]"
+                  className="mx-2 mt-1 ml-0 min-h-[150px] w-full resize-y rounded border px-1"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                 />
               </label>
               <button
-                className="col-span-1 col-start-2 col-end-3 bg-gray-500 px-3 py-1 rounded-sm hover:brightness-95"
+                className="col-span-1 col-start-2 col-end-3 rounded-sm bg-gray-500 px-3 py-1 hover:brightness-95"
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
@@ -134,7 +134,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
                 Cancel
               </button>
               <button
-                className="col-span-1 col-start-3 col-end-4 bg-check-green px-3 py-1 disabled:bg-green-200 disabled:text-gray-400 rounded-sm hover:brightness-95 disabled:brightness-100 disabled:cursor-not-allowed"
+                className="col-span-1 col-start-3 col-end-4 rounded-sm bg-check-green px-3 py-1 hover:brightness-95 disabled:cursor-not-allowed disabled:bg-green-200 disabled:text-gray-400 disabled:brightness-100"
                 type="submit"
                 disabled={!student || !message}
               >

--- a/frontend/components/communications/CommsCreationPopup.tsx
+++ b/frontend/components/communications/CommsCreationPopup.tsx
@@ -69,6 +69,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
         >
           &times;
         </a>
+        <h3 className="mb-3 px-5 text-xl">Register communication</h3>
         <section className="">
           {loading ? (
             <SpinnerCircular
@@ -83,7 +84,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
               className="grid grid-cols-4 justify-items-center gap-y-2"
               onSubmit={submit}
             >
-              <label className="col-span-2 w-9/12 pl-2">
+              <label className="col-span-4 w-11/12 pl-2">
                 Student
                 <Select
                   className="mt-1"
@@ -113,18 +114,17 @@ const CommsCreationPopup: FC<CCPProps> = ({
                   })}
                 />
               </label>
-
-              <label className="col-span-2 pl-2">
+              <label className="col-span-4 w-11/12 pl-2">
                 Information
                 <textarea
                   placeholder="Communication Information"
-                  className="mx-2 mt-1 w-9/12 resize-y border-2 px-1"
+                  className="mx-2 mt-1 w-full ml-0 resize-y border-2 px-1 min-h-[150px]"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                 />
               </label>
               <button
-                className="col-span-1 col-start-2 col-end-3 bg-gray-500 px-3 py-1"
+                className="col-span-1 col-start-2 col-end-3 bg-gray-500 px-3 py-1 rounded-sm hover:brightness-95"
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
@@ -134,7 +134,7 @@ const CommsCreationPopup: FC<CCPProps> = ({
                 Cancel
               </button>
               <button
-                className="col-span-1 col-start-3 col-end-4 bg-check-green px-3 py-1 disabled:bg-green-200 disabled:text-gray-400"
+                className="col-span-1 col-start-3 col-end-4 bg-check-green px-3 py-1 disabled:bg-green-200 disabled:text-gray-400 rounded-sm hover:brightness-95"
                 type="submit"
                 disabled={!student || !message}
               >

--- a/frontend/components/communications/CommsTable.tsx
+++ b/frontend/components/communications/CommsTable.tsx
@@ -16,6 +16,13 @@ type CommsTableProps = {
   setShowDeleteForm: Dispatch<SetStateAction<boolean>>;
 };
 
+function compareStudentComm(a: StudentComm, b: StudentComm): number {
+  if (a.name !== b.name)
+      return a.name >= b.name ? 1 : -1
+
+  return a.registrationTime <= b.registrationTime ? 1 : -1;
+}
+
 const CommsTable: FC<CommsTableProps> = ({
   studentComms,
   setCommsToDelete,
@@ -37,7 +44,7 @@ const CommsTable: FC<CommsTableProps> = ({
       <tbody>
         {studentComms && studentComms.length ? (
           studentComms
-            .sort((a, b) => (a.name >= b.name ? 1 : -1))
+            .sort((a, b) => compareStudentComm(a, b))
             .map((comm) => (
               <CommsTableRow
                 key={comm.id}

--- a/frontend/components/communications/CommsTable.tsx
+++ b/frontend/components/communications/CommsTable.tsx
@@ -26,8 +26,11 @@ const CommsTable: FC<CommsTableProps> = ({
       <thead className="sticky top-0 bg-white">
         <tr>
           <th className="w-1/4 py-4 text-left text-lg">Student Name</th>
+          <th className="w-1/4 text-left text-lg">
+            Information
+          </th>
           <th className="w-1/4 text-right text-lg">
-            Communication Information
+            Time
           </th>
         </tr>
       </thead>
@@ -41,6 +44,7 @@ const CommsTable: FC<CommsTableProps> = ({
                 commsId={comm.id}
                 studentName={comm.name}
                 commsMessage={comm.commMessage}
+                registrationTime={comm.registrationTime}
                 setCommsToDelete={setCommsToDelete}
                 setShowDeleteForm={setShowDeleteForm}
               />

--- a/frontend/components/communications/CommsTable.tsx
+++ b/frontend/components/communications/CommsTable.tsx
@@ -17,9 +17,7 @@ type CommsTableProps = {
 };
 
 function compareStudentComm(a: StudentComm, b: StudentComm): number {
-  if (a.name !== b.name)
-      return a.name >= b.name ? 1 : -1
-
+  if (a.name !== b.name) return a.name >= b.name ? 1 : -1;
   return a.registrationTime <= b.registrationTime ? 1 : -1;
 }
 
@@ -33,12 +31,8 @@ const CommsTable: FC<CommsTableProps> = ({
       <thead className="sticky top-0 bg-white">
         <tr>
           <th className="w-1/4 py-4 text-left text-lg">Student Name</th>
-          <th className="w-1/4 text-left text-lg">
-            Information
-          </th>
-          <th className="w-1/4 text-right text-lg">
-            Time
-          </th>
+          <th className="w-1/4 text-left text-lg">Information</th>
+          <th className="w-1/4 text-right text-lg">Time</th>
         </tr>
       </thead>
       <tbody>

--- a/frontend/components/communications/CommsTableRow.tsx
+++ b/frontend/components/communications/CommsTableRow.tsx
@@ -46,8 +46,8 @@ const CommsTableRow: FC<CommsTableRowProps> = ({
           />
         )}
       </td>
-      <td>{commsMessage}</td>
-      <td className="pr-3 text-right">
+      <td className="py-4 ">{commsMessage}</td>
+      <td className="py-4 pr-3 text-right">
         {new Date(registrationTime).toLocaleString()}
       </td>
     </tr>

--- a/frontend/components/communications/CommsTableRow.tsx
+++ b/frontend/components/communications/CommsTableRow.tsx
@@ -33,18 +33,20 @@ const CommsTableRow: FC<CommsTableRowProps> = ({
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
-      <td className="flex flex-row py-4 pl-3">
-        {studentName}
-        {hovering && (
-          <TrashIcon
-            className="h-6 w-6 pl-1 hover:cursor-pointer"
-            color="#F14A3B"
-            onClick={() => {
-              setCommsToDelete(commsId);
-              setShowDeleteForm(true);
-            }}
-          />
-        )}
+      <td className="m-auto py-4 pl-3">
+        <div className="flex flex-row">
+          {studentName}
+          {hovering && (
+            <TrashIcon
+              className="h-6 w-6 pl-1 hover:cursor-pointer"
+              color="#F14A3B"
+              onClick={() => {
+                setCommsToDelete(commsId);
+                setShowDeleteForm(true);
+              }}
+            />
+          )}
+        </div>
       </td>
       <td className="py-4 ">{commsMessage}</td>
       <td className="py-4 pr-3 text-right">

--- a/frontend/components/communications/CommsTableRow.tsx
+++ b/frontend/components/communications/CommsTableRow.tsx
@@ -4,6 +4,7 @@ import { Dispatch, FC, SetStateAction, useState } from 'react';
 type CommsTableRowProps = {
   studentName: string;
   commsMessage: string;
+  registrationTime: number[];
   commsId: string;
   /**
    * set the communication id to delete
@@ -19,6 +20,7 @@ type CommsTableRowProps = {
 const CommsTableRow: FC<CommsTableRowProps> = ({
   studentName,
   commsMessage,
+  registrationTime,
   commsId,
   setCommsToDelete,
   setShowDeleteForm,
@@ -31,7 +33,7 @@ const CommsTableRow: FC<CommsTableRowProps> = ({
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
-      <td className="flex flex-row py-4">
+      <td className="flex flex-row py-4 pl-3">
         {studentName}
         {hovering && (
           <TrashIcon
@@ -45,6 +47,9 @@ const CommsTableRow: FC<CommsTableRowProps> = ({
         )}
       </td>
       <td>{commsMessage}</td>
+      <td className="pr-3 text-right">
+        {new Date(registrationTime[0], registrationTime[1]-1, registrationTime[2], registrationTime[3], registrationTime[4], registrationTime[5]).toLocaleString()}
+      </td>
     </tr>
   );
 };

--- a/frontend/components/communications/CommsTableRow.tsx
+++ b/frontend/components/communications/CommsTableRow.tsx
@@ -4,7 +4,7 @@ import { Dispatch, FC, SetStateAction, useState } from 'react';
 type CommsTableRowProps = {
   studentName: string;
   commsMessage: string;
-  registrationTime: number[];
+  registrationTime: number;
   commsId: string;
   /**
    * set the communication id to delete
@@ -48,7 +48,7 @@ const CommsTableRow: FC<CommsTableRowProps> = ({
       </td>
       <td>{commsMessage}</td>
       <td className="pr-3 text-right">
-        {new Date(registrationTime[0], registrationTime[1]-1, registrationTime[2], registrationTime[3], registrationTime[4], registrationTime[5]).toLocaleString()}
+        {new Date(registrationTime).toLocaleString()}
       </td>
     </tr>
   );

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -260,7 +260,7 @@ export type StudentComm = {
   studentId: UUID;
   name: string;
   commMessage: string;
-  registrationTime: number;
+  registrationTime: Date;
   id: UUID;
 };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -252,7 +252,7 @@ export enum CommunicationType {
 export type Communication = {
   message: string;
   type: CommunicationType;
-  registrationTime: number[]
+  registrationTime: number
   id: UUID;
 };
 
@@ -260,7 +260,7 @@ export type StudentComm = {
   studentId: UUID;
   name: string;
   commMessage: string;
-  registrationTime: number[]
+  registrationTime: number
   id: UUID;
 };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -252,6 +252,7 @@ export enum CommunicationType {
 export type Communication = {
   message: string;
   type: CommunicationType;
+  registrationTime: number[]
   id: UUID;
 };
 
@@ -259,6 +260,7 @@ export type StudentComm = {
   studentId: UUID;
   name: string;
   commMessage: string;
+  registrationTime: number[]
   id: UUID;
 };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -252,7 +252,7 @@ export enum CommunicationType {
 export type Communication = {
   message: string;
   type: CommunicationType;
-  registrationTime: number
+  registrationTime: number;
   id: UUID;
 };
 
@@ -260,7 +260,7 @@ export type StudentComm = {
   studentId: UUID;
   name: string;
   commMessage: string;
-  registrationTime: number
+  registrationTime: number;
   id: UUID;
 };
 

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -198,7 +198,7 @@ const communications = () => {
             {error && <Error error={error} className="mb-4" />}
             <div>
               <button
-                className="mx-2 my-1 bg-osoc-btn-primary px-2 py-1 text-white rounded-sm hover:brightness-95"
+                className="mx-2 my-1 rounded-sm bg-osoc-btn-primary px-2 py-1 text-white hover:brightness-95"
                 onClick={() => setOpenPopup(true)}
               >
                 Add New
@@ -229,7 +229,7 @@ const communications = () => {
                 ]}
               >
                 <button
-                  className="my-1 mr-2 bg-osoc-yellow px-2 py-1 text-white disabled:bg-yellow-300 disabled:text-gray-200 rounded-sm hover:brightness-95 disabled:brightness-100 disabled:cursor-not-allowed"
+                  className="my-1 mr-2 rounded-sm bg-osoc-yellow px-2 py-1 text-white hover:brightness-95 disabled:cursor-not-allowed disabled:bg-yellow-300 disabled:text-gray-200 disabled:brightness-100"
                   disabled={communications.length === 0}
                 >
                   Download CSV

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -92,7 +92,7 @@ const communications = () => {
               studentId: student.id,
               name: student.firstName + ' ' + student.lastName,
               commMessage: csc.message,
-              registrationTime: csc.registrationTime,
+              registrationTime: new Date(csc.registrationTime),
               id: csc.id,
             });
           });
@@ -162,7 +162,7 @@ const communications = () => {
             studentId: studentId,
             name,
             commMessage: message,
-            registrationTime: response.data.registrationTime,
+            registrationTime: new Date(response.data.registrationTime),
             id: response.data.id,
           } as StudentComm,
         ];
@@ -210,7 +210,7 @@ const communications = () => {
                       id: comm.id,
                       name: comm.name,
                       message: comm.commMessage,
-                      timestamp: new Date(comm.registrationTime).toString(),
+                      timestamp: comm.registrationTime.toString(),
                     };
                   })
                 }

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -92,6 +92,7 @@ const communications = () => {
               studentId: student.id,
               name: student.firstName + ' ' + student.lastName,
               commMessage: csc.message,
+              registrationTime: csc.registrationTime,
               id: csc.id,
             });
           });
@@ -149,6 +150,8 @@ const communications = () => {
         })
       );
 
+      console.log(response);
+
       // add new communication locally
       const _stud = students.find((stud) => stud.id === studentId);
       const name = _stud ? _stud.firstName + ' ' + _stud.lastName : '';
@@ -159,6 +162,7 @@ const communications = () => {
             studentId: studentId,
             name,
             commMessage: message,
+            registrationTime: response.data.registrationTime,
             id: response.data.id,
           } as StudentComm,
         ];
@@ -193,6 +197,12 @@ const communications = () => {
           <div className="mx-auto mt-16 mb-32 w-11/12 p-0 md:w-3/5">
             {error && <Error error={error} className="mb-4" />}
             <div>
+              <button
+                className="mx-2 my-1 bg-osoc-btn-primary px-2 py-1 text-white rounded-sm"
+                onClick={() => setOpenPopup(true)}
+              >
+                Add New
+              </button>
               <CsvDownloader
                 datas={communications}
                 filename="communications"
@@ -212,21 +222,19 @@ const communications = () => {
                     id: 'commMessage',
                     displayName: 'message',
                   },
+                  {
+                    id: 'registrationTime',
+                    displayName: 'timestamp',
+                  },
                 ]}
               >
                 <button
-                  className="my-1 mr-2 bg-osoc-yellow px-2 py-1 text-white disabled:bg-yellow-300 disabled:text-gray-200"
+                  className="my-1 mr-2 bg-osoc-yellow px-2 py-1 text-white disabled:bg-yellow-300 disabled:text-gray-200 rounded-sm"
                   disabled={communications.length === 0}
                 >
                   Download CSV
                 </button>
               </CsvDownloader>
-              <button
-                className="mx-2 my-1 bg-osoc-btn-primary px-2 py-1 text-white"
-                onClick={() => setOpenPopup(true)}
-              >
-                Add New
-              </button>
             </div>
             <CommsTable
               studentComms={communications}

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -198,7 +198,7 @@ const communications = () => {
             {error && <Error error={error} className="mb-4" />}
             <div>
               <button
-                className="mx-2 my-1 bg-osoc-btn-primary px-2 py-1 text-white rounded-sm"
+                className="mx-2 my-1 bg-osoc-btn-primary px-2 py-1 text-white rounded-sm hover:brightness-95"
                 onClick={() => setOpenPopup(true)}
               >
                 Add New
@@ -229,7 +229,7 @@ const communications = () => {
                 ]}
               >
                 <button
-                  className="my-1 mr-2 bg-osoc-yellow px-2 py-1 text-white disabled:bg-yellow-300 disabled:text-gray-200 rounded-sm"
+                  className="my-1 mr-2 bg-osoc-yellow px-2 py-1 text-white disabled:bg-yellow-300 disabled:text-gray-200 rounded-sm hover:brightness-95 disabled:brightness-100 disabled:cursor-not-allowed"
                   disabled={communications.length === 0}
                 >
                   Download CSV

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -204,16 +204,14 @@ const communications = () => {
                 Add New
               </button>
               <CsvDownloader
-                datas={
-                  communications.map((comm) => {
-                    return {
-                      id: comm.id,
-                      name: comm.name,
-                      message: comm.commMessage,
-                      timestamp: comm.registrationTime.toString(),
-                    };
-                  })
-                }
+                datas={communications.map((comm) => {
+                  return {
+                    id: comm.id,
+                    name: comm.name,
+                    message: comm.commMessage,
+                    timestamp: comm.registrationTime.toString(),
+                  };
+                })}
                 filename="communications"
                 suffix
                 className="inline-block cursor-default"

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -204,7 +204,16 @@ const communications = () => {
                 Add New
               </button>
               <CsvDownloader
-                datas={communications}
+                datas={
+                  communications.map((comm) => {
+                    return {
+                      id: comm.id,
+                      name: comm.name,
+                      message: comm.commMessage,
+                      timestamp: new Date(comm.registrationTime).toString(),
+                    };
+                  })
+                }
                 filename="communications"
                 suffix
                 className="inline-block cursor-default"
@@ -212,19 +221,19 @@ const communications = () => {
                 columns={[
                   {
                     id: 'id',
-                    displayName: 'id',
+                    displayName: 'Id',
                   },
                   {
                     id: 'name',
-                    displayName: 'name',
+                    displayName: 'Student name',
                   },
                   {
-                    id: 'commMessage',
-                    displayName: 'message',
+                    id: 'message',
+                    displayName: 'Communication info',
                   },
                   {
-                    id: 'registrationTime',
-                    displayName: 'timestamp',
+                    id: 'timestamp',
+                    displayName: 'Time',
                   },
                 ]}
               >


### PR DESCRIPTION
This PR improves the communications page by adjusting styling and layout of certain components and adding a timestamp to each communication. Without the timestamp all communications would just be placed randomly. By having a timestamp users can see when a communication was registered and the last communication to each student is always shown first.

**Breaking change checklist**:
- [x] I've updated the existing tests to account for the changes in expected behaviour
- [x] I've updated the documentation to reflect the new behaviour
- [x] I've updated the `osoc.yaml` file
- [x] I've updated the frontend to make use of the timestamp field, alongside improving the communications page UI