### PR TITLE
Adjust the styling of status suggest/set

### DIFF
--- a/frontend/components/student/StudentView.tsx
+++ b/frontend/components/student/StudentView.tsx
@@ -435,21 +435,21 @@ const StudentView: React.FC<StudentViewProp> = ({
         >
           <div className={`flex w-[400px] flex-row justify-between`}>
             <button
-              className={`w-[30%] bg-check-green py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
+              className={`w-[30%] rounded-sm bg-check-green py-[2px] px-1 py-1 text-sm font-medium text-white hover:brightness-95`}
               onClick={() => setSuggestion('Yes')}
               type={`submit`}
             >
               Suggest Yes
             </button>
             <button
-              className={`w-[30%] bg-check-orange py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
+              className={`w-[30%] rounded-sm bg-check-orange py-[2px] px-1 py-1 text-sm font-medium text-white hover:brightness-95`}
               onClick={() => setSuggestion('Maybe')}
               type={`submit`}
             >
               Suggest Maybe
             </button>
             <button
-              className={`w-[30%] bg-check-red py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
+              className={`w-[30%] rounded-sm bg-check-red py-[2px] px-1 py-1 text-sm font-medium text-white hover:brightness-95`}
               onClick={() => setSuggestion('No')}
               type={`submit`}
             >
@@ -458,7 +458,7 @@ const StudentView: React.FC<StudentViewProp> = ({
           </div>
           <textarea
             placeholder="Motivation"
-            className="mt-3 w-full resize-y rounded border min-h-[100px]"
+            className="mt-3 min-h-[100px] w-full resize-y rounded border"
             value={motivation}
             onChange={(e) => setMotivation(e.target.value || '')}
           />
@@ -467,7 +467,7 @@ const StudentView: React.FC<StudentViewProp> = ({
             (sugg) => sugg.suggester.id === user.id
           ).length > 0 && (
             <button
-              className={`w-[100%] bg-check-gray py-[2px] text-sm text-white rounded-sm hover:brightness-95`}
+              className={`w-[100%] rounded-sm bg-check-gray py-[2px] text-sm text-white hover:brightness-95`}
               onClick={() => setSuggestion('Remove')}
               type={`submit`}
             >
@@ -538,7 +538,7 @@ const StudentView: React.FC<StudentViewProp> = ({
 
           {/* button to submit the admin status choice */}
           <button
-            className={`bg-check-gray px-2 py-[2px] text-sm rounded-sm hover:brightness-95`}
+            className={`rounded-sm bg-check-gray px-2 py-[2px] text-sm hover:brightness-95`}
             type={`submit`}
           >
             Submit

--- a/frontend/components/student/StudentView.tsx
+++ b/frontend/components/student/StudentView.tsx
@@ -433,23 +433,23 @@ const StudentView: React.FC<StudentViewProp> = ({
             };
           }}
         >
-          <div className={`flex w-[380px] flex-row justify-between`}>
+          <div className={`flex w-[400px] flex-row justify-between`}>
             <button
-              className={`w-[30%] bg-check-green py-[2px] text-sm text-white shadow-md shadow-gray-400`}
+              className={`w-[30%] bg-check-green py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
               onClick={() => setSuggestion('Yes')}
               type={`submit`}
             >
               Suggest Yes
             </button>
             <button
-              className={`w-[30%] bg-check-orange py-[2px] text-sm text-white shadow-md shadow-gray-400`}
+              className={`w-[30%] bg-check-orange py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
               onClick={() => setSuggestion('Maybe')}
               type={`submit`}
             >
               Suggest Maybe
             </button>
             <button
-              className={`w-[30%] bg-check-red py-[2px] text-sm text-white shadow-md shadow-gray-400`}
+              className={`w-[30%] bg-check-red py-[2px] text-sm text-white rounded-sm font-medium px-1 py-1 hover:brightness-95`}
               onClick={() => setSuggestion('No')}
               type={`submit`}
             >
@@ -458,7 +458,7 @@ const StudentView: React.FC<StudentViewProp> = ({
           </div>
           <textarea
             placeholder="Motivation"
-            className="mt-3 w-full resize-y border-2 border-check-gray"
+            className="mt-3 w-full resize-y rounded border min-h-[100px]"
             value={motivation}
             onChange={(e) => setMotivation(e.target.value || '')}
           />
@@ -467,7 +467,7 @@ const StudentView: React.FC<StudentViewProp> = ({
             (sugg) => sugg.suggester.id === user.id
           ).length > 0 && (
             <button
-              className={`w-[100%] bg-check-gray py-[2px] text-sm text-white shadow-md shadow-gray-400`}
+              className={`w-[100%] bg-check-gray py-[2px] text-sm text-white rounded-sm hover:brightness-95`}
               onClick={() => setSuggestion('Remove')}
               type={`submit`}
             >
@@ -480,7 +480,7 @@ const StudentView: React.FC<StudentViewProp> = ({
         <form
           className={`${
             user.role == UserRole.Admin ? 'visible' : 'hidden'
-          } mt-10 flex flex-row justify-between border-2 p-2`}
+          } mt-5 flex flex-row justify-between border-2 p-2`}
           onSubmit={(e) => {
             e.preventDefault();
             if (status.label != myStudent.status) {
@@ -538,7 +538,7 @@ const StudentView: React.FC<StudentViewProp> = ({
 
           {/* button to submit the admin status choice */}
           <button
-            className={`bg-check-gray px-2 py-[2px] text-sm shadow-md shadow-gray-400`}
+            className={`bg-check-gray px-2 py-[2px] text-sm rounded-sm hover:brightness-95`}
             type={`submit`}
           >
             Submit


### PR DESCRIPTION
This small PR does some changes to the styling of the student status suggest/set UI. The shadows on the buttons are now gone (these were the only buttons in the entire application which had shadows), the buttons are rounded and have the same hover effect I have given certain other buttons to make them more responsive. The textarea also had it's border changed to be rounded and thinner, just like other textareas/boxes.
Before:
![image](https://user-images.githubusercontent.com/15368970/169653349-6311bb00-7366-4eb7-b9ee-1c459a70c776.png)
After:
![image](https://user-images.githubusercontent.com/15368970/169653461-c73da5d3-8b51-403d-a9a9-3abebcdc2dcc.png)
