### PR TITLE
Make header fixed

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -74,7 +74,7 @@ const Header: React.FC<HeaderProps> = ({ setError }: HeaderProps) => {
   };
 
   return (
-    <header className="flex h-fit w-full flex-col items-center justify-between px-4 shadow-lg sm:h-12 sm:flex-row">
+    <header className="fixed mb-4 flex h-fit w-full flex-col items-center justify-between px-4 shadow-lg sm:h-12 sm:flex-row">
       <div className="flex flex-row items-center">
         <img
           src="https://osoc.be/img/logo/logo-osoc-color.svg"

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -74,7 +74,7 @@ const Header: React.FC<HeaderProps> = ({ setError }: HeaderProps) => {
   };
 
   return (
-    <header className="fixed mb-4 flex h-fit w-full flex-col items-center justify-between px-4 shadow-lg sm:h-12 sm:flex-row">
+    <header className="fixed z-[100] mb-4 flex h-fit w-full flex-col items-center justify-between bg-white px-4 shadow-lg sm:h-12 sm:flex-row">
       <div className="flex flex-row items-center">
         <img
           src="https://osoc.be/img/logo/logo-osoc-color.svg"

--- a/frontend/components/StudentSidebar.tsx
+++ b/frontend/components/StudentSidebar.tsx
@@ -363,10 +363,10 @@ const StudentSidebar: React.FC<StudentsSidebarProps> = ({
   return (
     // holds searchbar + hide filter button
     <div
-      className="sidebar mt-[50px] max-h-screen py-4 sm:mt-0"
+      className="sidebar top-[62px] bg-osoc-neutral-bg px-4 pt-4 sm:mt-0"
       ref={elementRef}
     >
-      <div className="flex max-h-[calc(100vh-32px)] flex-col">
+      <div className="flex max-h-screen flex-col sm:max-h-[calc(100vh-90px)]">
         <div className="mb-3 flex w-full flex-col items-center justify-between lg:flex-row">
           {/* The students searchbar */}
           <div className="justify-left md:w-[calc(100% - 200px)] mb-3 flex w-[80%] md:ml-0 lg:mb-0 ">
@@ -662,7 +662,7 @@ const StudentSidebar: React.FC<StudentsSidebarProps> = ({
         </div>
 
         {/* These are the student tiles */}
-        <div ref={scrollRef} className="max-h-[100%] grow overflow-y-auto">
+        <div ref={scrollRef} className="grow overflow-y-auto">
           <div className="col-span-full border-b-2 border-gray-400 pb-1 pr-2 text-right text-xs font-normal">
             {filterAmount + ' total results'}
           </div>

--- a/frontend/components/communications/CommsTable.tsx
+++ b/frontend/components/communications/CommsTable.tsx
@@ -63,7 +63,7 @@ const CommsTable: FC<CommsTableProps> = ({
 
   return (
     <table className="w-full table-fixed">
-      <thead className="sticky top-0 bg-white">
+      <thead className="sticky top-[48px] bg-white">
         <tr>
           <th className="w-1/4 py-4 text-left text-lg">
             <div className="flex flex-row items-center justify-start">

--- a/frontend/components/student/StudentView.tsx
+++ b/frontend/components/student/StudentView.tsx
@@ -306,7 +306,7 @@ const StudentView: React.FC<StudentViewProp> = ({
   const [suggestion, setSuggestion] = useState('');
   const [motivation, setMotivation] = useState('');
   const [deletePopup, setDeletePopup] = useState(false);
-  const [error, setError]: [string, (error: string) => void] = useState('');
+  const [error, setError] = useState('');
   const router = useRouter();
   let controller = new AbortController();
 
@@ -362,9 +362,9 @@ const StudentView: React.FC<StudentViewProp> = ({
   const pronouns = answers.commonPronouns || answers.otherPronouns;
   return (
     <div className={`flex flex-col-reverse justify-between xl:flex-row`}>
-      {error && <Error error={error} className="mb-4" />}
+      {error && <Error error={error} setError={setError} className="mb-4" />}
       {/* hold the student information */}
-      <div className="mx-8 flex w-full flex-col bg-osoc-neutral-bg px-4 py-3">
+      <div className="mx-8 flex flex-col bg-osoc-neutral-bg px-4 py-3">
         <div className="flex flex-row pt-2">
           <h1 className="text-4xl font-semibold">
             {answers.preferredName ||
@@ -386,6 +386,7 @@ const StudentView: React.FC<StudentViewProp> = ({
         </div>
         <div className="flex flex-col">
           <h3 className="pt-12 text-2xl">Suggestions</h3>
+          {suggestion.length === 0 && <p>No suggestions yet.</p>}
           {myStudent.statusSuggestions.map((statusSuggestion) => (
             <StudentStatusSuggestion
               key={statusSuggestion.suggester.id}
@@ -397,7 +398,7 @@ const StudentView: React.FC<StudentViewProp> = ({
       </div>
 
       {/* holds suggestion controls */}
-      <div className={`mr-6 ml-6 mb-6 flex flex-col xl:mb-0 xl:ml-0`}>
+      <div className={`mr-8 ml-8 mb-6 flex flex-col xl:mb-0 xl:ml-0`}>
         {/* regular coach status suggestion form */}
         <form
           className={`border-2 p-2`}

--- a/frontend/components/student/StudentView.tsx
+++ b/frontend/components/student/StudentView.tsx
@@ -386,7 +386,9 @@ const StudentView: React.FC<StudentViewProp> = ({
         </div>
         <div className="flex flex-col">
           <h3 className="pt-12 text-2xl">Suggestions</h3>
-          {suggestion.length === 0 && <p>No suggestions yet.</p>}
+          {myStudent.statusSuggestions.length === 0 && (
+            <p>No suggestions yet.</p>
+          )}
           {myStudent.statusSuggestions.map((statusSuggestion) => (
             <StudentStatusSuggestion
               key={statusSuggestion.suggester.id}

--- a/frontend/components/users/UserTable.tsx
+++ b/frontend/components/users/UserTable.tsx
@@ -89,7 +89,7 @@ const UserTable: React.FC<UserTableProps> = ({
 
   return (
     <table className="w-full table-fixed">
-      <thead className="sticky top-0 bg-white">
+      <thead className="sticky top-[48px] bg-white">
         <tr>
           <th className="w-1/4 py-4">
             <div className="flex flex-row items-center justify-start">

--- a/frontend/pages/[editionName]/communications.tsx
+++ b/frontend/pages/[editionName]/communications.tsx
@@ -20,6 +20,7 @@ import CommsCreationPopup from '../../components/communications/CommsCreationPop
 import CsvDownloader from 'react-csv-downloader';
 import PersistLogin from '../../components/PersistLogin';
 import CommsDeletePopup from '../../components/communications/CommsDeletePopup';
+import Head from 'next/head';
 
 const PAGE_SIZE = 50;
 
@@ -152,8 +153,6 @@ const communications = () => {
         })
       );
 
-      console.log(response);
-
       // add new communication locally
       const _stud = students.find((stud) => stud.id === studentId);
       const name = _stud ? _stud.firstName + ' ' + _stud.lastName : '';
@@ -194,9 +193,12 @@ const communications = () => {
   return (
     <PersistLogin>
       <RouteProtection allowedRoles={[UserRole.Admin, UserRole.Coach]}>
-        <div className="h-screen">
+        <Head>
+          <title>{edition}: communication</title>
+        </Head>
+        <div className="min-w-screen flex min-h-screen">
           <Header setError={setError} />
-          <div className="mx-auto mt-16 mb-32 w-11/12 p-0 md:w-3/5">
+          <div className="mx-auto mt-[200px] mb-32 w-11/12 p-0 sm:mt-16 md:w-3/5">
             {error && (
               <Error error={error} className="mb-4" setError={setError} />
             )}

--- a/frontend/pages/[editionName]/projects.tsx
+++ b/frontend/pages/[editionName]/projects.tsx
@@ -436,13 +436,13 @@ const Projects: NextPage = () => {
               <section
                 className={`${
                   showSidebar ? 'visible' : 'hidden'
-                } relative mt-[14px] w-full bg-osoc-neutral-bg px-4 md:visible md:block md:w-[400px] md:max-w-[450px] lg:min-w-[450px]`}
+                } relative mt-[14px] w-full md:visible md:block md:w-[400px] md:max-w-[450px] lg:min-w-[450px]`}
               >
                 {/* button to close sidebar on mobile */}
                 <div
                   className={`${
                     showSidebar ? 'visible' : 'hidden'
-                  } absolute left-[24px] top-[16px] z-50 flex flex-col justify-center text-[30px] opacity-20 md:hidden`}
+                  } absolute left-[24px] top-[16px] z-50 flex flex-col text-[30px] opacity-20 md:hidden`}
                 >
                   <i onClick={() => setShowSidebar(!showSidebar)}>{arrow_in}</i>
                 </div>
@@ -463,7 +463,7 @@ const Projects: NextPage = () => {
                   <div
                     className={`${
                       showSidebar ? 'hidden' : 'visible w-auto'
-                    } flex flex-col justify-center text-[30px] opacity-20 md:hidden`}
+                    } flex flex-col text-[30px] opacity-20 md:hidden`}
                   >
                     <i onClick={() => setShowSidebar(!showSidebar)}>
                       {arrow_out}
@@ -536,7 +536,7 @@ const Projects: NextPage = () => {
                           user.role == UserRole.Admin
                             ? 'xl:mt-0 xl:h-auto'
                             : 'md:mt-0 md:h-auto'
-                        } mt-2 flex h-[36px] flex-row justify-center`}
+                        } mt-2 ml-4 flex h-[36px] flex-row justify-center sm:mx-0`}
                       >
                         {/* Button to show conflicts */}
                         <button

--- a/frontend/pages/[editionName]/projects.tsx
+++ b/frontend/pages/[editionName]/projects.tsx
@@ -431,7 +431,7 @@ const Projects: NextPage = () => {
         <div className="min-w-screen flex min-h-screen flex-col items-center">
           <Header setError={setError} />
           <DndProvider backend={HTML5Backend} key={1}>
-            <main className="flex w-full flex-row">
+            <main className="mt-[180px] flex w-full flex-row sm:mt-12">
               {/* Holds the sidebar with search, filter and student results */}
               <section
                 className={`${

--- a/frontend/pages/[editionName]/students.tsx
+++ b/frontend/pages/[editionName]/students.tsx
@@ -39,13 +39,13 @@ const Students: NextPage = () => {
   return (
     <PersistLogin>
       <RouteProtection allowedRoles={[UserRole.Admin, UserRole.Coach]}>
+        <Head>
+          <title>{edition}: students</title>
+        </Head>
         <div className="min-w-screen flex min-h-screen flex-col items-center">
-          <Head>
-            <title>{edition}: students</title>
-          </Head>
           <Header setError={setError} />
           <DndProvider backend={HTML5Backend} key={2}>
-            <main className="flex w-full flex-row">
+            <main className="mt-[180px] flex w-full flex-row sm:mt-12">
               {/* Holds the sidebar with search, filter and student results */}
               <section
                 className={`${

--- a/frontend/pages/[editionName]/students.tsx
+++ b/frontend/pages/[editionName]/students.tsx
@@ -50,13 +50,13 @@ const Students: NextPage = () => {
               <section
                 className={`${
                   showSidebar ? 'visible' : 'hidden'
-                } relative mt-[14px] w-full bg-osoc-neutral-bg px-4 md:visible md:block md:w-[400px] md:max-w-[450px] lg:min-w-[450px]`}
+                } relative mt-[14px] w-full md:visible md:block md:w-[400px] md:max-w-[450px] lg:min-w-[450px]`}
               >
                 {/* button to close sidebar on mobile */}
                 <div
                   className={`${
                     showSidebar ? 'visible' : 'hidden'
-                  } absolute left-[24px] top-[17px] flex flex-col justify-center text-[29px] opacity-20 md:hidden`}
+                  } absolute left-[24px] top-[16px] z-50 flex flex-col text-[30px] opacity-20 md:hidden`}
                 >
                   {/* button to close sidebar on mobile */}
                   <i onClick={() => setShowSidebar(!showSidebar)}>{arrow_in}</i>
@@ -79,7 +79,7 @@ const Students: NextPage = () => {
                   <div
                     className={`${
                       showSidebar ? 'hidden' : 'visible w-auto'
-                    } flex flex-col justify-center text-[30px] opacity-20 md:hidden`}
+                    } flex flex-col text-[30px] opacity-20 md:hidden`}
                   >
                     <i onClick={() => setShowSidebar(!showSidebar)}>
                       {arrow_out}

--- a/frontend/pages/editions.tsx
+++ b/frontend/pages/editions.tsx
@@ -122,14 +122,18 @@ const Editions: NextPage = () => {
         <Head>
           <title>Editions</title>
         </Head>
-        <div className="h-screen">
+        <div className="min-w-screen flex min-h-screen">
           <Header setError={setError} />
 
           {error && (
-            <Error error={error} className="mt-4 w-3/5" setError={setError} />
+            <Error
+              error={error}
+              className="mt-[200px] w-3/5 sm:mt-16"
+              setError={setError}
+            />
           )}
 
-          <div className="row-auto m-auto mt-4 grid w-9/12 grid-cols-1 items-center gap-4 md:mt-8 md:grid-cols-2 lg:mt-12 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="row-auto m-auto mt-[200px] grid w-9/12 grid-cols-1 items-center gap-4 sm:mt-16 md:mt-12 md:grid-cols-2 lg:mt-20 lg:grid-cols-3 xl:grid-cols-4">
             {showCreateForm ? (
               <EditionCreateForm
                 setShowCreateForm={setShowCreateForm}

--- a/frontend/pages/users.tsx
+++ b/frontend/pages/users.tsx
@@ -161,9 +161,9 @@ const Users: NextPage = () => {
         <title>Users</title>
       </Head>
       <RouteProtection allowedRoles={[UserRole.Admin, UserRole.Coach]}>
-        <div className="h-screen">
+        <div className="min-w-screen flex min-h-screen">
           <Header setError={setError} />
-          <div className="mx-auto mt-16 mb-32 w-11/12 p-0 md:w-3/5">
+          <div className="mx-auto mt-[200px] mb-32 w-11/12 p-0 sm:mt-16 md:w-3/5">
             {loading ? (
               <div className="relative top-1/2 translate-y-1/2">
                 <p className="mb-4 text-center text-2xl opacity-75">

--- a/frontend/styles/line.css
+++ b/frontend/styles/line.css
@@ -46,6 +46,7 @@
   visibility: hidden;
   position: absolute;
   z-index: 1;
+  max-width: 18vw;
 }
 .tooltip:hover .tooltiptext {
   visibility: visible;
@@ -74,7 +75,6 @@
 .sidebar {
   position: -webkit-sticky;
   position: sticky;
-  top: 0;
 }
 
 .i-inline > svg {


### PR DESCRIPTION
This fixes part of #254 
This makes the header stay fixed at the top of the page & makes the studentsidebar not be longer than the page view.
I also added a title to the communications page
and fixed a margin on the students page & added a 'no suggestions yet' placeholder

This also makes tooltips have a low max width since they were bugging out page width.