### PR TITLE
chore: fix loading icon on project tile

### DIFF
--- a/frontend/components/projects/ProjectTile.tsx
+++ b/frontend/components/projects/ProjectTile.tsx
@@ -320,6 +320,7 @@ const ProjectTile: React.FC<ProjectProp> = ({
    */
   useEffect(() => {
     if (JSON.stringify(projectInput) != JSON.stringify(myProjectBase)) {
+      setLoading(true);
       setMyProjectBase(projectInput as ProjectBase);
     } else {
       controller2.abort();
@@ -358,7 +359,6 @@ const ProjectTile: React.FC<ProjectProp> = ({
    * myProjectBase gets set to projectInput at the start.
    */
   useEffect(() => {
-    setLoading(true);
     controller.abort();
     controller = new AbortController();
     const signal = controller.signal;


### PR DESCRIPTION
sometimes loading icon on projecttile would show even when it shouldn't, not 100% sure why but this seems to fix it.